### PR TITLE
Fix incorrect calculation and display of accommodation availability in the date picker

### DIFF
--- a/includes/class-wc-accommodation-booking.php
+++ b/includes/class-wc-accommodation-booking.php
@@ -17,6 +17,7 @@ class WC_Accommodation_Booking {
 		add_filter( 'woocommerce_bookings_get_end_date_with_time', array( $this, 'add_checkout_time_to_booking_end_time' ), 10, 2 );
 		add_filter( 'get_booking_products_terms', array( $this, 'add_accommodation_to_booking_product_terms' ) );
 		add_filter( 'get_booking_products_args', array( $this, 'add_accommodation_to_booking_products_args' ) );
+		add_filter( 'woocommerce_booking_is_booked_on_day', array( $this, 'is_booked_on_day_check' ), 10, 4 );
 
 		add_action( 'woocommerce_new_booking', array( $this, 'update_start_end_time' ) );
 	}
@@ -134,6 +135,24 @@ class WC_Accommodation_Booking {
 		$time  = str_pad( $time, 6, '0' );
 
 		return substr( $datetime, 0, 8 ) . $time;
+	}
+	
+	/**
+	 * Verify that a booking's date range intersects with the date range of the block we are checking it against.
+	 * Designed to hook into the is_booked_on_day method of the wc-booking class, which does not make this check
+	 *
+	 * @return boolean
+	 */	
+	public function is_booked_on_day_check( $is_booked, $wc_booking, $block_start, $block_end ) {
+		$multiday_booking = date( 'Y-m-d', $wc_booking->start ) < date( 'Y-m-d', $wc_booking->end );
+		if ( $multiday_booking ) {
+			// Make sure that the booking's end date is not on or before the start date of the block we are checking it against
+			//	or that the booking's start date is not on or after the end date of the block we are checking it against
+			if ( date( 'YmdHi', $wc_booking->end ) <= date( 'YmdHi', $block_start ) || date( 'YmdHi', $wc_booking->start ) >= date( 'YmdHi', $block_end ) ) {
+				$is_booked = false;
+			}
+		}
+		return $is_booked;
 	}
 }
 

--- a/includes/class-wc-product-accommodation-booking.php
+++ b/includes/class-wc-product-accommodation-booking.php
@@ -113,4 +113,24 @@ class WC_Product_Accommodation_Booking extends WC_Product_Booking {
 		return apply_filters( 'woocommerce_get_price_html', $price_html, $this );
 	}
 
+	/**
+	 * Get an array of blocks within in a specified date range
+	 *
+	 * The WC_Product_Booking class does not account for 'nights' as a valid duration unit so it retrieves every minute of each day as a block,
+	 * severly slowing down the load time of the page.
+	 *
+	 * @param       $start_date
+	 * @param       $end_date
+	 * @param array $intervals
+	 * @param int   $resource_id
+	 * @param array $booked
+	 *
+	 * @return array
+	 */
+	public function get_blocks_in_range( $start_date, $end_date, $intervals = array(), $resource_id = 0, $booked = array() ) {
+
+		$blocks_in_range = $this->get_blocks_in_range_for_day( $start_date, $end_date, $resource_id, $booked );
+
+		return array_unique( $blocks_in_range );
+	}
 }

--- a/includes/class-wc-product-accommodation-booking.php
+++ b/includes/class-wc-product-accommodation-booking.php
@@ -133,4 +133,76 @@ class WC_Product_Accommodation_Booking extends WC_Product_Booking {
 
 		return array_unique( $blocks_in_range );
 	}
+	
+	/**
+	 * Check the resources availability against all the blocks.
+	 *
+	 * Identical to the get_blocks_availability function of the wc_product_booking class, except that the error returned accurately gives
+	 * the available quantity of places remaining on the day that triggered the error.
+	 *
+	 * @param  string $start_date
+	 * @param  string $end_date
+	 * @param  int    $qty
+	 * @param  int    $resource_id
+	 * @param  WC_Product_Booking_Resource|null $booking_resource
+	 * @return string|WP_Error
+	 */
+	public function get_blocks_availability( $start_date, $end_date, $qty, $resource_id, $booking_resource ) {
+		$blocks   = $this->get_blocks_in_range( $start_date, $end_date, '', $resource_id );
+		$interval = 'hour' === $this->get_duration_unit() ? $this->get_duration() * 60 : $this->get_duration();
+
+		if ( ! $blocks ) {
+			return false;
+		}
+
+		/**
+		 * Grab all existing bookings for the date range
+		 * @var array
+		 */
+		$existing_bookings = $this->get_bookings_in_date_range( $start_date, $end_date, $resource_id );
+		$available_qtys    = array();
+
+		// Check all blocks availability
+		foreach ( $blocks as $block ) {
+			$available_qty       = $this->has_resources() && $booking_resource->has_qty() ? $booking_resource->get_qty() : $this->get_qty();
+			$qty_booked_in_block = 0;
+
+			foreach ( $existing_bookings as $existing_booking ) {
+				$block_end = strtotime( "+{$interval} minutes", $block );
+				if ( $existing_booking->is_booked_on_day( $block, $block_end ) ) {
+					$qty_to_add = $this->has_person_qty_multiplier() ? max( 1, array_sum( $existing_booking->get_persons() ) ) : 1;
+
+					if ( $this->has_resources() ) {
+						if ( $existing_booking->get_resource_id() === absint( $resource_id ) || ( ! $booking_resource->has_qty() && $existing_booking->get_resource() && ! $existing_booking->get_resource()->has_qty() ) ) {
+							$qty_booked_in_block += $qty_to_add;
+						}
+					} else {
+						$qty_booked_in_block += $qty_to_add;
+					}
+				}
+			}
+
+			$available_qty = $available_qty - $qty_booked_in_block;
+
+			// Remaining places are less than requested qty, return an error.
+			if ( $available_qty < $qty ) {
+				if ( in_array( $this->get_duration_unit(), array( 'hour', 'minute' ) ) ) {
+					return new WP_Error( 'Error', sprintf(
+						_n( 'There is %d place remaining', 'There are %d places remaining', $available_qty , 'woocommerce-bookings' ),
+						$available_qty
+					) );
+				} else {
+					return new WP_Error( 'Error', sprintf(
+						_n( 'There is %1$d place remaining on %2$s', 'There are %1$d places remaining on %2$s', $available_qty , 'woocommerce-bookings' ),
+						$available_qty,
+						date_i18n( wc_date_format(), $block )
+					) );
+				}
+			}
+
+			$available_qtys[] = $available_qty;
+		}
+
+		return min( $available_qtys );
+	}
 }


### PR DESCRIPTION
With multiday bookings, the WC_Product_Booking class checks the availability of each block in the selected range of dates. This is calculated incorrectly because the is_booked_on_day method of the WC_Booking class does not take into account blocks that both start and end before the booking date starts or after it ends. This pull request modifies the WC_Accommodation_Booking class to hook into the "woocommerce_booking_is_booked_on_day" filter and fix this.

The error message displayed to the user when the get_blocks_availability method of the WC_Product_Booking class encounters a block with no availability incorrectly reports the number of available spaces from whatever block had the maximum number. This pull request overrides the get_blocks_availability function in the WC_Product_Accommodation_Booking class to return the correct error.