### PR TITLE
Changed hook to plugins_loaded from woocommerce_loaded for includes

### DIFF
--- a/includes/class-wc-accommodation-bookings-plugin.php
+++ b/includes/class-wc-accommodation-bookings-plugin.php
@@ -75,7 +75,7 @@ class WC_Accommodation_Bookings_Plugin {
 		}
 
 		add_action( 'init', array( $this, 'load_plugin_textdomain' ), 5 );
-		add_action( 'woocommerce_loaded', array( $this, 'includes' ), 20 );
+		add_action( 'plugins_loaded', array( $this, 'includes' ), 20 );
 		add_filter( 'plugin_row_meta', array( $this, 'plugin_row_meta' ), 10, 2 );
 		add_action( 'wp_enqueue_scripts', array( $this, 'booking_form_styles' ) );
 


### PR DESCRIPTION
Fixes #90  .

#### Changes proposed in this Pull Request:
- Changed hook to `plugins_loaded` from `woocommerce_loaded` for main includes method

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

