### PR TITLE
Fix some notices and error on plugin activation.

### DIFF
--- a/includes/admin/class-wc-accommodation-booking-admin-panels.php
+++ b/includes/admin/class-wc-accommodation-booking-admin-panels.php
@@ -16,13 +16,22 @@ class WC_Accommodation_Booking_Admin_Panels {
 		add_filter( 'product_type_selector' , array( $this, 'product_type_selector' ) );
 		add_filter( 'product_type_options', array( $this, 'product_type_options' ), 15 );
 
-		add_action( 'woocommerce_product_write_panels', array( $this, 'panels' ) );
+		add_action( 'init', array( $this, 'init' ) );
+
 		add_action( 'woocommerce_product_options_general_product_data', array( $this, 'general_product_data' ) );
 
 		add_filter( 'woocommerce_product_data_tabs', array( $this, 'hide_shipping_tab' ) );
 		add_action( 'woocommerce_product_write_panel_tabs', array( $this, 'add_tabs' ), 5 );
 
 		add_action( 'woocommerce_process_product_meta', array( $this,'save_product_data' ), 25 );
+	}
+
+	public function init() {
+		if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
+			add_action( 'woocommerce_product_write_panels', array( $this, 'panels' ) );
+		} else {
+			add_action( 'woocommerce_product_data_panels', array( $this, 'panels' ) );
+		}
 	}
 
 	/**

--- a/includes/class-wc-accommodation-bookings-plugin.php
+++ b/includes/class-wc-accommodation-bookings-plugin.php
@@ -75,7 +75,7 @@ class WC_Accommodation_Bookings_Plugin {
 		}
 
 		add_action( 'init', array( $this, 'load_plugin_textdomain' ), 5 );
-		add_action( 'woocommerce_loaded', array( $this, 'includes' ), 20 );
+		add_action( 'plugins_loaded', array( $this, 'includes' ), 20 );
 		add_filter( 'plugin_row_meta', array( $this, 'plugin_row_meta' ), 10, 2 );
 		add_action( 'wp_enqueue_scripts', array( $this, 'booking_form_styles' ) );
 

--- a/includes/class-wc-product-accommodation-booking.php
+++ b/includes/class-wc-product-accommodation-booking.php
@@ -48,17 +48,19 @@ class WC_Product_Accommodation_Booking extends WC_Product_Booking {
 	/**
 	 * Customers define how many nights they want to stay. There is no concept
 	 * of "fixed" durations for accommodations.
+	 * @param  string $context
 	 * @return string
 	 */
-	public function get_duration_type() {
+	public function get_duration_type( $context = 'view' ) {
 		return 'customer';
 	}
 
 	/**
 	 * Our duration is nights instead of days
+	 * @param  string $context
 	 * @return string
 	 */
-	public function get_duration_unit() {
+	public function get_duration_unit( $context = 'view' ) {
 		return 'night';
 	}
 


### PR DESCRIPTION
The change at https://github.com/woocommerce/woocommerce-bookings/commit/2d4c7ae8#diff-fc37c2ec242b590decd6ee7fbf8d5c4cL52 broke `woocommerce-accomodation-bookings` and `woocommerce-bookings`. I get `( ! ) Fatal error: Class 'WC_Product_Booking' not found in /Users/boro/dev/woocommerce-accommodation-bookings/includes/class-wc-product-accommodation-booking.php on line 10` (edited)

This is because `woocommerce-accomodation-bookings` triggers on `woocommerce_loaded` with priority 20, but it seems this triggers before `plugins_loaded`.

As for whether this will work with Bookings pre 1.10, in theory, I think it should be good.

Bookings pre 1.10 will use `woocommerce_loaded` which triggers before `plugins_loaded`

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

