### PR TITLE
Allow accommodation product to be created.

### DIFF
--- a/includes/class-wc-product-accommodation-booking.php
+++ b/includes/class-wc-product-accommodation-booking.php
@@ -13,12 +13,20 @@ class WC_Product_Accommodation_Booking extends WC_Product_Booking {
 	 * Set up our new type and fill out some basic info
 	 */
 	public function __construct( $product ) {
-		$this->product_type = 'accommodation-booking';
+		$this->product_type = $this->get_type();
 		parent::__construct( $product );
 
 		$this->wc_booking_duration_type = 'customer';
 		$this->wc_booking_duration_unit = 'night';
 		$this->wc_booking_duration = 1;
+	}
+
+	/**
+	 * Override product type
+	 * @return string
+	 */
+	public function get_type() {
+		return 'accommodation-booking';
 	}
 
 	/**


### PR DESCRIPTION
Fixes #97.

#### Changes proposed in this Pull Request:
- We need to override `get_type` to the proper type, as when eventually lands [here](https://github.com/woocommerce/woocommerce/blob/master/includes/abstracts/abstract-wc-product.php#L124) it calculates properly.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

