### PR TITLE
Register data store so that when doing `wc_get_product` it can be rea…

### DIFF
--- a/includes/class-wc-accommodation-booking.php
+++ b/includes/class-wc-accommodation-booking.php
@@ -19,6 +19,18 @@ class WC_Accommodation_Booking {
 		add_filter( 'get_booking_products_args', array( $this, 'add_accommodation_to_booking_products_args' ) );
 
 		add_action( 'woocommerce_new_booking', array( $this, 'update_start_end_time' ) );
+		add_filter( 'woocommerce_data_stores', array( $this, 'register_data_stores' ), 10 );
+	}
+
+	/**
+	 * Register data stores for bookings.
+	 *
+	 * @param  array  $data_stores
+	 * @return array
+	 */
+	public function register_data_stores( $data_stores = array() ) {
+		$data_stores['product-accommodation-booking'] = $data_stores['product-booking'];
+		return $data_stores;
 	}
 
 	/**

--- a/includes/class-wc-product-accommodation-booking.php
+++ b/includes/class-wc-product-accommodation-booking.php
@@ -110,8 +110,10 @@ class WC_Product_Accommodation_Booking extends WC_Product_Booking {
 
 		}
 
-		if ( $this->wc_booking_min_duration > 1 ) {
-			$display_price = $display_price / $this->wc_booking_min_duration;
+		$min_duration = absint( get_post_meta( $this->get_id(), '_wc_booking_min_duration', true ) );
+
+		if ( $min_duration > 1 ) {
+			$display_price = $display_price / $min_duration;
 		}
 
 		if ( $display_price ) {


### PR DESCRIPTION
…d properly.

Fixes #100, #101, #102.

#### Changes proposed in this Pull Request:
- Register data store so that when doing `wc_get_product` it can be read properly. If extending `WC_Product` and overriding `get_type`, we need to make sure we register the data store as well, because of [this](https://github.com/woocommerce/woocommerce/blob/master/includes/abstracts/abstract-wc-product.php#L124).
- Fix direct access to class variable

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

