### PR TITLE
Fix fatal error in case the plugin is included multiple times.

### DIFF
--- a/includes/class-wc-product-accommodation-booking.php
+++ b/includes/class-wc-product-accommodation-booking.php
@@ -3,6 +3,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+if ( ! class_exists( 'WC_Product_Accommodation_Booking' ) ) :
+
 /**
  * Class that creates our new accommodation booking product type
  * Mostly inheirted from WC_Product_Booking (code reuse!) but overrides a few methods
@@ -151,3 +153,5 @@ class WC_Product_Accommodation_Booking extends WC_Product_Booking {
 		return array_unique( $blocks_in_range );
 	}
 }
+
+endif;


### PR DESCRIPTION
Fixes #105.

#### Changes proposed in this Pull Request:
- Wrap the class definition in a `class_exists` check

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

