### PR TITLE
Fix resource calculation issue.

### DIFF
--- a/includes/class-wc-accommodation-booking-date-picker.php
+++ b/includes/class-wc-accommodation-booking-date-picker.php
@@ -153,7 +153,7 @@ class WC_Accommodation_Booking_Date_Picker {
 				$full_days = array();
 
 				// if all resources were used, set the id to 0 (date-picker.js depends on that)
-				if ( $product->has_resources() && $product->is_resource_assignment_type( 'automatic' ) ) {
+				if ( $product->has_resources() && count( $product->get_resources() ) === count( array_keys( $check_in_out_days[ $which ] ) ) && $product->is_resource_assignment_type( 'automatic' ) ) {
 					$full_days = call_user_func_array( 'array_intersect', $check_in_out_days[ $which ] );
 				}
 

--- a/includes/class-wc-accommodation-booking-date-picker.php
+++ b/includes/class-wc-accommodation-booking-date-picker.php
@@ -63,9 +63,6 @@ class WC_Accommodation_Booking_Date_Picker {
 	 * @param array $booked_data_array
 	 */
 	public function add_partially_booked_dates( $booked_data_array, $product ) {
-
-		$booked_day_counts     = array();
-
 		// this array will contain the start and the end of all bookings
 		$check_in_out_days     = array(
 			'in' => array(),
@@ -98,21 +95,10 @@ class WC_Accommodation_Booking_Date_Picker {
 
 			$check_in_out_days['in'][ $resource ][] = date( 'Y-n-j', $check_date );
 
-			// Loop over all booked days in this booking
+			// Loop over all booked days in this booking and mark them as fully booked (the last one will be filtered by check out filter)
 			while ( $check_date < $booking->end ) {
 
 				$js_date = date( 'Y-n-j', $check_date );
-
-				if ( $check_date < current_time( 'timestamp' ) ) {
-					$check_date = strtotime( '+1 day', $check_date );
-					continue;
-				}
-
-				if ( isset( $booked_day_counts[ $js_date ] ) ) {
-					$booked_day_counts[ $js_date ]++;
-				} else {
-					$booked_day_counts[ $js_date ] = 1;
-				}
 
 				$check_date = strtotime( '+1 day', $check_date );
 				$booked_data_array['fully_booked_days'][ date( 'Y-n-j', $check_date ) ][ $resource ] = true;
@@ -168,12 +154,6 @@ class WC_Accommodation_Booking_Date_Picker {
 						unset( $booked_data_array['fully_booked_days'][ $day ][ $resource ] );
 					}
 				}
-			}
-		}
-
-		foreach ( $booked_day_counts as $booked_date => $number_of_bookings ) {
-			if ( $number_of_bookings < $available_quantity ) {
-				$booked_data_array['partially_booked_days'][ $booked_date ][0] = true;
 			}
 		}
 

--- a/includes/class-wc-accommodation-booking-date-picker.php
+++ b/includes/class-wc-accommodation-booking-date-picker.php
@@ -82,7 +82,8 @@ class WC_Accommodation_Booking_Date_Picker {
 		foreach ( $existing_bookings as $booking ) {
 
 			$check_date  = $booking->start;
-			$check_in_out_days['in'][] = date( 'Y-n-j', $check_date );
+			$resource = $booking->get_resource_id();
+			$check_in_out_days['in'][ $resource ][] = date( 'Y-n-j', $check_date );
 
 			// Loop over all booked days in this booking
 			while ( $check_date < $booking->end ) {
@@ -101,42 +102,78 @@ class WC_Accommodation_Booking_Date_Picker {
 				}
 
 				$check_date = strtotime( '+1 day', $check_date );
+				$booked_data_array['fully_booked_days'][ date( 'Y-n-j', $check_date ) ][ $resource ] = true;
 			}
 
-			$check_in_out_days['out'][] = date( 'Y-n-j', $check_date );
+			$check_in_out_days['out'][ $resource ][] = date( 'Y-n-j', $check_date );
+		}
+
+		// if it has resources, remove resource id 0 from the fully and partially booked list
+		if ( $product->has_resources() ) {
+			foreach ( array( 'partially_booked_days', 'fully_booked_days' ) as $which ) {
+				foreach ( $booked_data_array[ $which ] as $day => $resource ) {
+					$booked_data_array[ $which ][ $day ] = array_filter(
+						$booked_data_array[ $which ][ $day ],
+						function( $key ) {
+							return $key !== 0;
+						},
+						ARRAY_FILTER_USE_KEY
+					);
+				}
+			}
 		}
 
 		// mark as fully booked all days that intersect the check in and check out date
-		$fully_booked = array_intersect( $check_in_out_days['in'], $check_in_out_days['out'] );
+		$resources = array_intersect( array_keys( $check_in_out_days['in'] ), array_keys( $check_in_out_days['out'] ) );
+		$fully_booked = array();
 
-		foreach ( $fully_booked as $day ) {
-			$booked_data_array['fully_booked_days'][ $day ][0] = true;
-		}
+		foreach ( $resources as $resource ) {
+			$single_fully_booked = array_intersect( $check_in_out_days['in'][ $resource ], $check_in_out_days['out'][ $resource ] );
 
-		// since we're marking the fully booked checkin days as partially booked, we will exclude the intersection (fully booked ones)
-		$check_in_out_days['in'] = array_diff( $check_in_out_days['in'], $fully_booked );
+			if ( ! empty( $single_fully_booked ) ) {
+				$fully_booked[ $resource ][] = $single_fully_booked;
 
-		// since we're marking the checkout days as partially booked, we will exclude the intersection (fully booked ones)
-		$check_in_out_days['out'] = array_diff( $check_in_out_days['out'], $fully_booked );
+				// since we're marking the fully booked checkin days as partially booked, we will exclude the intersection (fully booked ones)
+				$check_in_out_days['in'][ $resource ] = array_diff( $check_in_out_days['in'][ $resource ], $single_fully_booked );
 
-		foreach ( $check_in_out_days['in'] as $day ) {
-			// if the first checkout day for a booking was marked as fully booked, move to partially booked
-			if ( ! empty( $booked_data_array['fully_booked_days'][ $day ] ) ) {
-				$booked_data_array['partially_booked_days'][ $day ][0] = $booked_data_array['fully_booked_days'][ $day ];
-				unset( $booked_data_array['fully_booked_days'][ $day ] );
+				// since we're marking the checkout days as partially booked, we will exclude the intersection (fully booked ones)
+				$check_in_out_days['out'][ $resource ] = array_diff( $check_in_out_days['out'][ $resource ], $single_fully_booked );
 			}
 		}
 
-		foreach ( $check_in_out_days['out'] as $day ) {
-			// check out days should be marked as partially booked
-			$partially_booked = 1;
-
-			if ( ! empty( $booked_data_array['partially_booked_days'][ $day ] ) ) {
-				$partially_booked = $booked_data_array['partially_booked_days'][ $day ];
-				unset( $booked_data_array['partially_booked_days'][ $day ] );
+		foreach ( $fully_booked as $resource => $days ) {
+			foreach ( $days as $day ) {
+				$booked_data_array['fully_booked_days'][ $day ][ $resource ] = true;
 			}
+		}
 
-			$booked_data_array['partially_booked_days'][ $day ][0] = $partially_booked;
+		foreach ( $check_in_out_days['in'] as $resource => $days ) {
+			foreach ( $days as $day ) {
+				// if the first checkout day for a booking was marked as fully booked, move to partially booked
+				if ( ! empty( $booked_data_array['fully_booked_days'][ $day ][ $resource ] ) ) {
+					$booked_data_array['partially_booked_days'][ $day ][ $resource ] = $booked_data_array['fully_booked_days'][ $day ][ $resource ];
+					unset( $booked_data_array['fully_booked_days'][ $day ][ $resource ] );
+				}
+			}
+		}
+
+		foreach ( $check_in_out_days['out'] as $resource => $days ) {
+			foreach ( $days as $day ) {
+				// check out days should be marked as partially booked
+				$partially_booked = 1;
+
+				if ( ! empty( $booked_data_array['partially_booked_days'][ $day ][ $resource ] ) ) {
+					$partially_booked = $booked_data_array['partially_booked_days'][ $day ][ $resource ];
+					unset( $booked_data_array['partially_booked_days'][ $day ][ $resource ] );
+				}
+
+				// if the last checkout day for a booking was marked as fully booked, unset as it will be partially booked
+				if ( ! empty( $booked_data_array['fully_booked_days'][ $day ][ $resource ] ) ) {
+					unset( $booked_data_array['fully_booked_days'][ $day ][ $resource ] );
+				}
+
+				$booked_data_array['partially_booked_days'][ $day ][ $resource ] = $partially_booked;
+			}
 		}
 
 		foreach ( $booked_day_counts as $booked_date => $number_of_bookings ) {

--- a/includes/class-wc-accommodation-bookings-plugin.php
+++ b/includes/class-wc-accommodation-bookings-plugin.php
@@ -139,6 +139,7 @@ class WC_Accommodation_Bookings_Plugin {
 	 */
 	public function includes() {
 		include( WC_ACCOMMODATION_BOOKINGS_INCLUDES_PATH . 'class-wc-product-accommodation-booking.php' );
+		include( WC_ACCOMMODATION_BOOKINGS_INCLUDES_PATH . 'class-wc-product-accommodation-booking-resource.php' );
 		include( WC_ACCOMMODATION_BOOKINGS_INCLUDES_PATH . 'class-wc-accommodation-booking.php' );
 		include( WC_ACCOMMODATION_BOOKINGS_INCLUDES_PATH . 'class-wc-accommodation-booking-cart-manager.php' );
 		include( WC_ACCOMMODATION_BOOKINGS_INCLUDES_PATH . 'class-wc-accommodation-booking-date-picker.php' );

--- a/includes/class-wc-product-accommodation-booking-resource.php
+++ b/includes/class-wc-product-accommodation-booking-resource.php
@@ -1,0 +1,45 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! class_exists( 'WC_Product_Accommodation_Booking_Resource' ) ) :
+
+/**
+ * Class that creates our new accommodation booking product resource type
+ * Mostly inheirted from WC_Product_Booking_Resource (code reuse!) but overrides a few methods
+ */
+class WC_Product_Accommodation_Booking_Resource extends WC_Product_Booking_Resource {
+	/**
+	 * Return the base cost (set at parent level).
+	 *
+	 * @return float
+	 */
+	public function get_base_cost() {
+		if ( $this->get_parent_id() && ( $parent = wc_get_product( $this->get_parent_id() ) ) && $parent->is_type( 'accommodation-booking' ) ) {
+			$costs = $parent->get_resource_base_costs();
+			$cost  = isset( $costs[ $this->get_id() ] ) ? $costs[ $this->get_id() ] : '';
+		} else {
+			$cost   = '';
+		}
+
+		return (float) $cost;
+	}
+
+	/**
+	 * Return the block cost  (set at parent level).
+	 *
+	 * @return float
+	 */
+	public function get_block_cost() {
+		if ( $this->get_parent_id() && ( $parent = wc_get_product( $this->get_parent_id() ) ) && $parent->is_type( 'accommodation-booking' ) ) {
+			$costs  = $parent->get_resource_block_costs();
+			$cost   = isset( $costs[ $this->get_id() ] ) ? $costs[ $this->get_id() ] : '';
+		} else {
+			$cost   = '';
+		}
+		return (float) $cost;
+	}
+}
+
+endif;

--- a/includes/class-wc-product-accommodation-booking-resource.php
+++ b/includes/class-wc-product-accommodation-booking-resource.php
@@ -7,11 +7,16 @@ if ( ! class_exists( 'WC_Product_Accommodation_Booking_Resource' ) ) :
 
 /**
  * Class that creates our new accommodation booking product resource type
- * Mostly inheirted from WC_Product_Booking_Resource (code reuse!) but overrides a few methods
+ * Mostly inherited from WC_Product_Booking_Resource (code reuse!) but overrides a few methods
+ *
+ * @version 1.0.9
+ * @since 1.0.9
  */
 class WC_Product_Accommodation_Booking_Resource extends WC_Product_Booking_Resource {
 	/**
 	 * Return the base cost (set at parent level).
+	 * @version 1.0.9
+	 * @since 1.0.9
 	 *
 	 * @return float
 	 */
@@ -28,6 +33,8 @@ class WC_Product_Accommodation_Booking_Resource extends WC_Product_Booking_Resou
 
 	/**
 	 * Return the block cost  (set at parent level).
+	 * @version 1.0.9
+	 * @since 1.0.9
 	 *
 	 * @return float
 	 */

--- a/includes/class-wc-product-accommodation-booking.php
+++ b/includes/class-wc-product-accommodation-booking.php
@@ -23,12 +23,49 @@ class WC_Product_Accommodation_Booking extends WC_Product_Booking {
 		$this->wc_booking_duration = 1;
 	}
 
+
+	/**
+	 * Get resource by ID.
+	 * Need to override this to return the proper resource class.
+	 *
+	 * @param  int $id
+	 * @return WC_Product_Booking_Resource object
+	 */
+	public function get_resource( $id ) {
+		$resource = parent::get_resource( $id );
+
+		if ( $resource ) {
+			$resource = new WC_Product_Accommodation_Booking_Resource( $id, $this->get_id() );
+		}
+
+		return $resource;
+	}
+
 	/**
 	 * Override product type
 	 * @return string
 	 */
 	public function get_type() {
 		return 'accommodation-booking';
+	}
+
+	/**
+	 * Get resources objects.
+	 *
+	 * @param WC_Product
+	 *
+	 * @return array(
+	 *   type WC_Product_Accommodation_Booking_Resource
+	 * )
+	 */
+	public function get_resources() {
+		$product_resources = array();
+
+		foreach ( $this->get_resource_ids() as $resource_id ) {
+			$product_resources[] = new WC_Product_Accommodation_Booking_Resource( $resource_id, $this->get_id() );
+		}
+
+		return $product_resources;
 	}
 
 	/**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "woocommerce-accommodation-bookings",
   "title": "WooCommerce Accommodation Bookings",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "homepage": "https://woocommerce.com/products/woocommerce-accommodation-bookings/",
   "repository": {
     "type": "git",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors:  woothemes, jshreve, akeda, bor0
 Tags: woocommerce, bookings, accommodations
 Requires at least: 4.1
 Tested up to: 4.6
-Stable tag: 1.0.8
+Stable tag: 1.0.9
 License: GNU General Public License v3.0
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -29,6 +29,15 @@ This extension extends Bookings and makes it possible to:
 Or use the automatic installation wizard through your admin panel, just search for this plugins name.
 
 == Changelog ==
+
+= 1.0.9 =
+* Fix - Additional updates for WooCommerce 3.0 compatibility.
+* Fix - Min/max rules not being applied.
+* Fix - Prices not being added to cart.
+* Fix - Align panel icons.
+* Fix - Fatal error when using older version of Bookings.
+* Fix - Logic for availability of dates with checkin/checkout.
+* Fix - Resource costs not being calculated.
 
 = 1.0.8 =
 * Fix - WooCommerce 3.0 compatibility.

--- a/woocommerce-accommodation-bookings.php
+++ b/woocommerce-accommodation-bookings.php
@@ -3,7 +3,7 @@
 Plugin Name: WooCommerce Accommodation Bookings
 Plugin URI: https://woocommerce.com/products/woocommerce-accommodation-bookings/
 Description: An accommodations add-on for the WooCommerce Bookings extension.
-Version: 1.0.8
+Version: 1.0.9
 Author: WooCommerce
 Author URI: https://woocommerce.com
 Text Domain: woocommerce-accommodation-bookings
@@ -19,5 +19,5 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 require_once( 'includes/class-wc-accommodation-bookings-plugin.php' );
-$plugin = new WC_Accommodation_Bookings_Plugin( __FILE__, '1.0.8' );
+$plugin = new WC_Accommodation_Bookings_Plugin( __FILE__, '1.0.9' );
 $plugin->run();


### PR DESCRIPTION
Alters #108 (add support for resources). Fixes #87, #107, #110.

#### Changes proposed in this Pull Request:
- Need to override a bunch of Bookings methods which depend on type. They were checking `bookings` against `WC_Product_Accommodation_Booking::get_type` which is `accommodation-bookings`.
- Alter availability logic to handle products with resources
- Remove old code which was skipping until check date matches current timestamp (today) to fix #110.

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

