### PR TITLE
Fixed css class to show tax fields

### DIFF
--- a/includes/admin/views/html-accommodation-booking-data.php
+++ b/includes/admin/views/html-accommodation-booking-data.php
@@ -74,6 +74,6 @@
 	</p>
 
 	<script type="text/javascript">
-		jQuery( '._tax_status_field' ).closest( '.show_if_simple' ).addClass( 'show_if_accommodation_booking' );
+		jQuery( '._tax_status_field' ).closest( '.show_if_simple' ).addClass( 'show_if_accommodation-booking' );
 	</script>
 </div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
-Tax fields were not being shown due to incorrect css class was being used. 

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

