### PR TITLE
Fix 112 Today showing partially available when not available.

### DIFF
--- a/includes/class-wc-accommodation-booking-date-picker.php
+++ b/includes/class-wc-accommodation-booking-date-picker.php
@@ -157,7 +157,7 @@ class WC_Accommodation_Booking_Date_Picker {
 
 		//move check in days that occure today to fully booked as they cannot be booked
 		$today = date( 'Y-n-j', current_time( 'timestamp' ) );
-		foreach ( $check_in_out_days[ 'in' ] as $reasource => $days ) {
+		foreach ( $check_in_out_days[ 'in' ] as $resource => $days ) {
 			foreach ( $days as $key => $day ) {
 				if ( $day === $today ) {
 					unset( $check_in_out_days[ 'in' ][ $resource ][ $key ] );

--- a/includes/class-wc-accommodation-booking-date-picker.php
+++ b/includes/class-wc-accommodation-booking-date-picker.php
@@ -155,6 +155,17 @@ class WC_Accommodation_Booking_Date_Picker {
 			}
 		}
 
+		//move check in days that occure today to fully booked as they cannot be booked
+		$today = date( 'Y-n-j', current_time( 'timestamp' ) );
+		foreach ( $check_in_out_days[ 'in' ] as $reasource => $days ) {
+			foreach ( $days as $key => $day ) {
+				if ( $day === $today ) {
+					unset( $check_in_out_days[ 'in' ][ $resource ][ $key ] );
+					$booked_data_array['fully_booked_days'][ $day ][ $resource ] = true;
+				}
+			}
+		}
+
 		// go through each checkin and checkout days and mark them as partially booked
 		foreach ( array( 'in', 'out' ) as $which ) {
 			foreach ( $check_in_out_days[ $which ] as $resource => $days ) {

--- a/readme.txt
+++ b/readme.txt
@@ -34,6 +34,7 @@ Or use the automatic installation wizard through your admin panel, just search f
 * Fix - Tax fields missing.
 * Fix - Display price is showing incorrectly.
 * Fix - Availability rules being ignored.
+* Fix - Today should be shown as booked if it has check out available only
 
 = 1.0.9 =
 * Fix - Additional updates for WooCommerce 3.0 compatibility.


### PR DESCRIPTION
Fixes #112 .

#### Changes proposed in this Pull Request:
- When `today` is start of the booking it should be marked as fully booked as there are no more actions available for that day. 

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

