### PR TITLE
If display cost is set it overides displayed price.

### DIFF
--- a/includes/class-wc-product-accommodation-booking.php
+++ b/includes/class-wc-product-accommodation-booking.php
@@ -141,15 +141,20 @@ class WC_Product_Accommodation_Booking extends WC_Product_Booking {
 	 * @return string
 	 */
 	public function get_price_html( $price = '' ) {
-		$tax_display_mode = get_option( 'woocommerce_tax_display_shop' );
-		if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
-			$display_price = $tax_display_mode == 'incl' ? $this->get_price_including_tax( 1, $this->get_price() ) : $this->get_price_excluding_tax( 1, $this->get_price() );
-		} else {
-			$display_price = $tax_display_mode == 'incl' ? wc_get_price_including_tax( $this, array( 'qty' => 1, 'price' => $this->get_price() ) ) : wc_get_price_excluding_tax( $this, array( 'qty' => 1, 'price' => $this->get_price() ) );
+
+		// If displau cost is set - user wants that to be displayed
+		$display_price = $this->get_display_cost();
+		if ( ! $display_price ) {
+			$tax_display_mode = get_option( 'woocommerce_tax_display_shop' );
+			if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
+				$display_price = $tax_display_mode == 'incl' ? $this->get_price_including_tax( 1, $this->get_price() ) : $this->get_price_excluding_tax( 1, $this->get_price() );
+			} else {
+				$display_price = $tax_display_mode == 'incl' ? wc_get_price_including_tax( $this, array( 'qty' => 1, 'price' => $this->get_price() ) ) : wc_get_price_excluding_tax( $this, array( 'qty' => 1, 'price' => $this->get_price() ) );
+			}
 		}
 
 		if ( $display_price ) {
-			if ( $this->has_additional_costs() ) {
+			if ( $this->has_additional_costs() || $this->get_display_cost() ) {
 				$price_html = sprintf( __( 'From %s per night', 'woocommerce-accommodation-bookings' ), wc_price( $display_price ) ) . $this->get_price_suffix();
 			} else {
 				$price_html = wc_price( $display_price ) . $this->get_price_suffix();

--- a/readme.txt
+++ b/readme.txt
@@ -30,6 +30,9 @@ Or use the automatic installation wizard through your admin panel, just search f
 
 == Changelog ==
 
+= 1.0.X =
+* Fix - Display cost not used when presenting price to the client.
+
 = 1.0.10 =
 * Fix - Tax fields missing.
 * Fix - Display price is showing incorrectly.


### PR DESCRIPTION
Fixes #123 .

#### Changes proposed in this Pull Request:
- When display cost is set it overrides calculated cost ( as per description in product edit UI )

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

