### PR TITLE
Added filter to allow range picker to be disabled

### DIFF
--- a/includes/class-wc-product-accommodation-booking.php
+++ b/includes/class-wc-product-accommodation-booking.php
@@ -89,7 +89,7 @@ class WC_Product_Accommodation_Booking extends WC_Product_Booking {
 	 * @return boolean
 	 */
 	public function is_range_picker_enabled() {
-		return true;
+		return apply_filters( 'woocommerce_accommodation_bookings_range_picker_enabled', true );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -32,6 +32,7 @@ Or use the automatic installation wizard through your admin panel, just search f
 
 = 1.0.X =
 * Fix - Display cost not used when presenting price to the client.
+* Feature - Add woocommerce_accommodation_bookings_range_picker_enabled to disable range picker. 
 
 = 1.0.10 =
 * Fix - Tax fields missing.


### PR DESCRIPTION
Fixes #126 .

#### Changes proposed in this Pull Request:
- Added `woocommerce_accommodation_bookings_range_picker_enabled` filter to be able to disable the range picker, if desired. 
- Bookings master already has a fix in for *Nights(s)*

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

