### PR TITLE
Added version_compare for Bookings < 1.10.7 compat

### DIFF
--- a/includes/admin/class-wc-accommodation-booking-admin-panels.php
+++ b/includes/admin/class-wc-accommodation-booking-admin-panels.php
@@ -70,18 +70,25 @@ class WC_Accommodation_Booking_Admin_Panels {
 		global $post, $bookable_product;
 		$post_id = $post->ID;
 
-		if ( empty( $bookable_product ) || $bookable_product->get_id() !== $post->ID ) {
-			$bookable_product = new WC_Product_Booking( $post->ID );
-		}
+		/**
+		 * Day restrictions added to Bookings 1.10.7
+		 * @todo  Remove version compare ~Aug 2018
+		 */
+		if ( version_compare( WC_BOOKINGS_VERSION, '1.10.7', '>=' ) ) {
 
-		$restricted_meta = $bookable_product->get_restricted_days();
+			if ( empty( $bookable_product ) || $bookable_product->get_id() !== $post->ID ) {
+				$bookable_product = new WC_Product_Booking( $post->ID );
+			}
 
-		for ( $i=0; $i < 7; $i++) {
+			$restricted_meta = $bookable_product->get_restricted_days();
 
-			if ( $restricted_meta && in_array( $i, $restricted_meta ) ) {
-				$restricted_days[ $i ] = $i;
-			} else {
-				$restricted_days[ $i ] = false;
+			for ( $i=0; $i < 7; $i++) {
+
+				if ( $restricted_meta && in_array( $i, $restricted_meta ) ) {
+					$restricted_days[ $i ] = $i;
+				} else {
+					$restricted_days[ $i ] = false;
+				}
 			}
 		}
 

--- a/includes/admin/views/html-accommodation-booking-availability.php
+++ b/includes/admin/views/html-accommodation-booking-availability.php
@@ -36,47 +36,56 @@
 		</p>
 
 		<?php
-			woocommerce_wp_checkbox(
-				array(
-					'id'          => '_wc_accommodation_booking_has_restricted_days',
-					'value'       => $bookable_product->has_restricted_days( 'edit' ) ? 'yes' : 'no',
-					'label'       => __( 'Restrict start days?', 'woocommerce-bookings' ),
-					'description' => __( 'Restrict bookings so that they can only start on certain days of the week. Does not affect availability.', 'woocommerce-bookings' ),
-				)
-			);
+			/**
+			 * Day restrictions added to Bookings 1.10.7
+			 * @todo  Remove version compare ~Aug 2018
+			 */
+			if ( version_compare( WC_BOOKINGS_VERSION, '1.10.7', '>=' ) ) :
+
+				woocommerce_wp_checkbox(
+					array(
+						'id'          => '_wc_accommodation_booking_has_restricted_days',
+						'value'       => $bookable_product->has_restricted_days( 'edit' ) ? 'yes' : 'no',
+						'label'       => __( 'Restrict start days?', 'woocommerce-bookings' ),
+						'description' => __( 'Restrict bookings so that they can only start on certain days of the week. Does not affect availability.', 'woocommerce-bookings' ),
+					)
+				);
 		?>
 
-		<div class="booking-day-restriction">
-			<table class="widefat">
-				<tbody>
-					<tr>
-						<td>&nbsp;</td>
+			<div class="booking-day-restriction">
+				<table class="widefat">
+					<tbody>
+						<tr>
+							<td>&nbsp;</td>
 
-			<?php
-				$weekdays = array(
-					__( 'Sunday', 'woocommerce-bookings' ),
-					__( 'Monday', 'woocommerce-bookings' ),
-					__( 'Tuesday', 'woocommerce-bookings' ),
-					__( 'Wednesday', 'woocommerce-bookings' ),
-					__( 'Thursday', 'woocommerce-bookings' ),
-					__( 'Friday', 'woocommerce-bookings' ),
-					__( 'Saturday', 'woocommerce-bookings' ),
-					);
+				<?php
+					$weekdays = array(
+						__( 'Sunday', 'woocommerce-bookings' ),
+						__( 'Monday', 'woocommerce-bookings' ),
+						__( 'Tuesday', 'woocommerce-bookings' ),
+						__( 'Wednesday', 'woocommerce-bookings' ),
+						__( 'Thursday', 'woocommerce-bookings' ),
+						__( 'Friday', 'woocommerce-bookings' ),
+						__( 'Saturday', 'woocommerce-bookings' ),
+						);
 
-				for ( $i=0;  $i < 7;  $i++) { 
-					?>
-						<td>
-							<label class="checkbox" for="_wc_accommodation_booking_restricted_days[<?php echo $i; ?>]"><?php echo $weekdays[ $i ]; ?>&nbsp;</label>
-							<input type="checkbox" class="checkbox" name="_wc_accommodation_booking_restricted_days[<?php echo $i; ?>]" id="_wc_accommodation_booking_restricted_days[<?php echo $i; ?>]" value="<?php echo $i; ?>" <?php checked( $restricted_days[ $i ], $i ); ?>>
-						</td>
-					<?php
-				}
-			?>
-						<td>&nbsp;</td>
-					</tr>
-				</tbody>
-			</table>
-		</div>
+					for ( $i=0;  $i < 7;  $i++) { 
+						?>
+							<td>
+								<label class="checkbox" for="_wc_accommodation_booking_restricted_days[<?php echo $i; ?>]"><?php echo $weekdays[ $i ]; ?>&nbsp;</label>
+								<input type="checkbox" class="checkbox" name="_wc_accommodation_booking_restricted_days[<?php echo $i; ?>]" id="_wc_accommodation_booking_restricted_days[<?php echo $i; ?>]" value="<?php echo $i; ?>" <?php checked( $restricted_days[ $i ], $i ); ?>>
+							</td>
+						<?php
+					}
+				?>
+							<td>&nbsp;</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+
+		<?php endif; ?>
+
 	</div>
 	<div class="options_group">
 		<div class="table_grid">


### PR DESCRIPTION
Fixes backward compatibility so that this will work with Bookings versions less than 1.10.7 .

#### Changes proposed in this Pull Request:
- Use `version_compare` to skip the blocks of code that implement restricted days.

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

