### PR TITLE
Bookings outside of available range being checked for availability

### DIFF
--- a/includes/class-wc-accommodation-booking-date-picker.php
+++ b/includes/class-wc-accommodation-booking-date-picker.php
@@ -138,7 +138,7 @@ class WC_Accommodation_Booking_Date_Picker {
 
 		// Using all existing bookings we will calculate start and end time for each booking.
 		// Those times will be considered for switching particular day from full to partially booked days.
-		$existing_bookings  = WC_Bookings_Controller::get_bookings_for_objects( array( $product->get_id() ) );
+		$existing_bookings  = WC_Bookings_Controller::get_all_existing_bookings( $product );
 		foreach ( $existing_bookings as $booking ) {
 
 			$resource   = $booking->get_resource_id();

--- a/readme.txt
+++ b/readme.txt
@@ -30,6 +30,9 @@ Or use the automatic installation wizard through your admin panel, just search f
 
 == Changelog ==
 
+= 1.1.1 =
+* Fix - Bookings outside of available range being checked for availability.
+
 = 1.1.0 =
 * Fix - Display cost not used when presenting price to the client.
 * Add - Add woocommerce_accommodation_bookings_range_picker_enabled to disable range picker.


### PR DESCRIPTION
Fixes #142 .

#### Changes proposed in this Pull Request:
- Use `get_all_existing_bookings` instead of `get_bookings_for_objects` so that min/max dates are added to query. 

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

