### PR TITLE
Set the minimum value for max nights to 1

### DIFF
--- a/includes/admin/views/html-accommodation-booking-data.php
+++ b/includes/admin/views/html-accommodation-booking-data.php
@@ -26,7 +26,7 @@
 			'desc_tip'          => true,
 			'type'              => 'number',
 			'custom_attributes' => array(
-				'min'  => '',
+				'min'  => '1',
 				'step' => '1'
 			)
 		) );

--- a/readme.txt
+++ b/readme.txt
@@ -33,6 +33,7 @@ Or use the automatic installation wizard through your admin panel, just search f
 = 1.1.1 =
 * Fix - PHP Notice when fully booked array is empty.
 * Fix - Bookings outside of available range being checked for availability.
+* Fix - Maximum number of nights allowed option set to 0 breaks page.
 
 = 1.1.0 =
 * Fix - Display cost not used when presenting price to the client.


### PR DESCRIPTION
Fixes #148

#### Changes proposed in this Pull Request:
- Set the `min` value of the field to `1`.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

