### PR TITLE
Reset booking cost on save and update block cost with the base cost

### DIFF
--- a/includes/admin/class-wc-accommodation-booking-admin-panels.php
+++ b/includes/admin/class-wc-accommodation-booking-admin-panels.php
@@ -197,6 +197,10 @@ class WC_Accommodation_Booking_Admin_Panels {
 			if ( '_wc_booking_display_cost' === $meta_key ) {
 				update_post_meta( $post_id, '_wc_display_cost', $value );
 			}
+
+			if ( '_wc_booking_base_cost' === $meta_key ) {
+				update_post_meta( $post_id, '_wc_booking_block_cost', $value );
+			}
 		}
 
 		// Availability
@@ -355,6 +359,7 @@ class WC_Accommodation_Booking_Admin_Panels {
 		}
 
 		update_post_meta( $post_id, '_wc_booking_pricing', $pricing );
+		update_post_meta( $post_id, '_wc_booking_cost', '' );
 
 		update_post_meta( $post_id, '_regular_price', '' );
 		update_post_meta( $post_id, '_sale_price', '' );

--- a/readme.txt
+++ b/readme.txt
@@ -30,6 +30,10 @@ Or use the automatic installation wizard through your admin panel, just search f
 
 == Changelog ==
 
+= 1.1.2 =
+* Fix - Bookable product base cost not being cleared when changing to an Accommodation product.
+* Fix - Update _wc_booking_block_cost when base cost is updated.
+
 = 1.1.1 =
 * Fix - PHP Notice when fully booked array is empty.
 * Fix - Bookings outside of available range being checked for availability.

--- a/readme.txt
+++ b/readme.txt
@@ -30,14 +30,12 @@ Or use the automatic installation wizard through your admin panel, just search f
 
 == Changelog ==
 
-= 1.1.2 =
-* Fix - Bookable product base cost not being cleared when changing to an Accommodation product.
-* Fix - Update _wc_booking_block_cost when base cost is updated.
-
 = 1.1.1 =
 * Fix - PHP Notice when fully booked array is empty.
 * Fix - Bookings outside of available range being checked for availability.
 * Fix - Maximum number of nights allowed option set to 0 breaks page.
+* Fix - Bookable product base cost not being cleared when changing to an Accommodation product.
+* Fix - Update _wc_booking_block_cost when base cost is updated.
 
 = 1.1.0 =
 * Fix - Display cost not used when presenting price to the client.


### PR DESCRIPTION
Fixes #124 .

#### Changes proposed in this Pull Request:
- Update `_wc_booking_block_cost` with base cost on save
- Remove `_wc_booking_cost` on save, accomodations doesn't use it and it causes issues when toggling a product between Booking and Accomodation.

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

