### PR TITLE
Fix undefined index for product-booking #160

### DIFF
--- a/includes/class-wc-accommodation-booking.php
+++ b/includes/class-wc-accommodation-booking.php
@@ -29,7 +29,9 @@ class WC_Accommodation_Booking {
 	 * @return array
 	 */
 	public function register_data_stores( $data_stores = array() ) {
-		$data_stores['product-accommodation-booking'] = $data_stores['product-booking'];
+		if ( isset( $data_stores['product-booking'] ) ) {
+			$data_stores['product-accommodation-booking'] = $data_stores['product-booking'];
+		}
 		return $data_stores;
 	}
 


### PR DESCRIPTION
Fixes #160.

#### Changes proposed in this Pull Request:
- This pull request will test if `product-booking` exists in the array passed to `register_data_stores` before using it

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

