### PR TITLE
Night count cost adjustment

### DIFF
--- a/includes/admin/class-wc-accommodation-booking-admin-panels.php
+++ b/includes/admin/class-wc-accommodation-booking-admin-panels.php
@@ -303,6 +303,13 @@ class WC_Accommodation_Booking_Admin_Panels {
 					$pricing[ $i ]['from'] = wc_clean( $_POST[ 'wc_accommodation_booking_pricing_from_day_of_week' ][ $i ] );
 					$pricing[ $i ]['to']   = wc_clean( $_POST[ 'wc_accommodation_booking_pricing_to_day_of_week' ][ $i ] );
 				break;
+				case 'blocks' :
+					$pricing[ $i ]['from'] = wc_clean( $_POST['wc_accommodation_booking_pricing_from_block'][ $i ] );
+					$pricing[ $i ]['to']   = wc_clean( $_POST['wc_accommodation_booking_pricing_to_block'][ $i ] );
+
+					$pricing[ $i ]['cost']     = wc_clean( $_POST['wc_accommodation_booking_pricing_block_cost'][ $i ] );
+					$pricing[ $i ]['modifier'] = 'equals';
+				break;
 			}
 		}
 		

--- a/includes/admin/views/html-accommodation-booking-rates-fields.php
+++ b/includes/admin/views/html-accommodation-booking-rates-fields.php
@@ -44,6 +44,7 @@
 				<option value="months" <?php selected( $rate['type'], 'months' ); ?>><?php _e( 'Range of months', 'woocommerce-accommodation-bookings' ); ?></option>
 				<option value="weeks" <?php selected( $rate['type'], 'weeks' ); ?>><?php _e( 'Range of weeks', 'woocommerce-accommodation-bookings' ); ?></option>
 				<option value="days" <?php selected( $rate['type'], 'days' ); ?>><?php _e( 'Range of nights during the week', 'woocommerce-accommodation-bookings' ); ?></option>
+				<option value="blocks" <?php selected( $rate['type'], 'blocks' ); ?>><?php _e( 'Night count', 'woocommerce-bookings' ); ?></option>
 			</select>
 		</div>
 	</td>
@@ -71,6 +72,9 @@
 		</div>
 		<div class="from_date">
 			<input type="text" class="date-picker" name="wc_accommodation_booking_pricing_from_date[]" value="<?php if ( $rate['type'] == 'custom' && ! empty( $rate['from'] ) ) echo esc_attr( $rate['from'] ) ?>" />
+		</div>
+		<div class="from">
+			<input type="number" name="wc_accommodation_booking_pricing_from_block[]" step="1" value="<?php if ( $rate['type'] == 'blocks' && ! empty( $rate['from'] ) ) echo esc_attr( $rate['from'] ) ?>" />
 		</div>
 	</td>
 	<td>
@@ -101,6 +105,10 @@
 
 		<div class="to_time">
 			<input type="time" class="time-picker" name="wc_accommodation_booking_pricing_to_time[]" value="<?php if ( strrpos( $rate['type'], 'time' ) === 0 && ! empty( $rate['to'] ) ) echo esc_attr( $rate['to'] ); ?>" placeholder="HH:MM" />
+		</div>
+
+		<div class="to">
+			<input type="number" name="wc_accommodation_booking_pricing_to_block[]" step="1" value="<?php if ( $rate['type'] == 'blocks' && ! empty( $rate['to'] ) ) echo esc_attr( $rate['to'] ); ?>" />
 		</div>
 	</td>
 	<td>


### PR DESCRIPTION
Attempt to fix  #62 .

#### Changes proposed in this Pull Request:
- Add one more option to select for price adjustments "Night count"
- Add fields to show up if the "night count" adjustment is selected (driven by WooCommerce Bookings JS)
- Save the rule to database if user selects this type of adjustment

#### Conflicts
If a user just selects one of the adjustments it works all fine. But if a users sets up multiple adjustments. The shown prices can show up quite inconsistent.  

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

