### PR TITLE
Remove duplicate person cost multiplier checkbox already defined in B…

### DIFF
--- a/includes/integrations/class-wc-accommodation-booking-addons.php
+++ b/includes/integrations/class-wc-accommodation-booking-addons.php
@@ -45,10 +45,6 @@ class WC_Accommodation_Booking_Addons {
 		}
 		?>
 		<tr class="<?php echo esc_attr( $css_classes ); ?>">
-			<td class="addon_wc_booking_person_qty_multiplier addon_required" width="50%">
-				<label for="addon_wc_accommodation_booking_person_qty_multiplier_<?php echo $loop; ?>"><?php _e( 'Bookings: Multiply cost by person count', 'woocommerce-accommodation-bookings' ); ?></label>
-				<input type="checkbox" id="addon_wc_accommodation_booking_person_qty_multiplier_<?php echo $loop; ?>" name="addon_wc_accommodation_booking_person_qty_multiplier[<?php echo $loop; ?>]" <?php checked( ! empty( $addon['wc_booking_person_qty_multiplier'] ), true ) ?> />
-			</td>
 			<td class="addon_wc_booking_block_qty_multiplier addon_required" width="50%">
 				<label for="addon_wc_accommodation_booking_block_qty_multiplier_<?php echo $loop; ?>"><?php _e( 'Bookings: Multiply cost by number of nights', 'woocommerce-accommodation-bookings' ); ?></label>
 				<input type="checkbox" id="addon_wc_accommodation_booking_block_qty_multiplier_<?php echo $loop; ?>" name="addon_wc_accommodation_booking_block_qty_multiplier[<?php echo $loop; ?>]" <?php checked( ! empty( $addon['wc_booking_block_qty_multiplier'] ), true ) ?> />

--- a/readme.txt
+++ b/readme.txt
@@ -40,6 +40,7 @@ If the prices shown on the product do not match the prices defined in the dashbo
 * Fix - Fatal error when disabling WooCommerce.
 * Fix - Undefined index notice.
 * Fix - Check for product before using it in order info.
+* Fix - Remove duplicate person cost multiplier checkbox.
 
 = 1.1.2 =
 * Fix - Corrupted check-in/check-out dates in DB.


### PR DESCRIPTION
…ookings

Fixes #175.

#### Changes proposed in this Pull Request:
- Remove duplicate person cost multiplier checkbox already defined in Bookings

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.
