### PR TITLE
Adds npm start script so Grunt does not have to be installed globally

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
   },
   "dependencies": {
     "grunt-cli": "^1.2.0"
+  },
+  "scripts": {
+    "start": "grunt"
   }
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- Adds 'grunt' to the npm start command.  Since I do not have grunt installed globally I need to run it from the node_modules folder.

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

