### PR TITLE
Check product object exists before calling its methods closes #197

### DIFF
--- a/includes/class-wc-accommodation-bookings-plugin.php
+++ b/includes/class-wc-accommodation-bookings-plugin.php
@@ -206,6 +206,10 @@ class WC_Accommodation_Bookings_Plugin {
 			foreach ( $accommodation_bookings as $accommodation_booking ) {
 				$product = wc_get_product( $accommodation_booking->post_id );
 
+				if ( ! is_a( $product, 'WC_Product' ) ) {
+					continue;				
+				}
+
 				if ( 'accommodation-booking' != $product->get_type() ) {
 					continue;
 				}

--- a/readme.txt
+++ b/readme.txt
@@ -38,6 +38,7 @@ If the prices shown on the product do not match the prices defined in the dashbo
 
 = 1.1.4 - 2018-xx-xx =
 * Add - PAO 3.0 compatibility.
+* Fix - Check product object before calling method to prevent errors.
 
 = 1.1.3 =
 * Fix - Fatal error when disabling WooCommerce.


### PR DESCRIPTION
Fixes #197

#### Changes proposed in this Pull Request:
* Fix - Check product object before calling method to prevent errors.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

