### PR TITLE
Accommodation duration unit is always one night.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 1.1.5 - 2018-XX-XX =
+* Fix - Overwrite get_duration function, to fix duration calculations.
+
 = 1.1.4 - 2018-10-23 =
 * Add - PAO 3.0 compatibility.
 * Fix - Check product object before calling method to prevent errors.

--- a/includes/class-wc-product-accommodation-booking.php
+++ b/includes/class-wc-product-accommodation-booking.php
@@ -227,6 +227,8 @@ class WC_Product_Accommodation_Booking extends WC_Product_Booking {
 
 	/**
 	 * Get duration.
+	 * 
+	 * Duration unit is always one night.
 	 *
 	 * @param  string $context
 	 * @return integer

--- a/includes/class-wc-product-accommodation-booking.php
+++ b/includes/class-wc-product-accommodation-booking.php
@@ -224,6 +224,16 @@ class WC_Product_Accommodation_Booking extends WC_Product_Booking {
 
 		return '';
 	}
+
+	/**
+	 * Get duration.
+	 *
+	 * @param  string $context
+	 * @return integer
+	 */
+	public function get_duration( $context = 'view' ) {
+		return 1;
+	}
 }
 
 endif;


### PR DESCRIPTION
Accommodation differs from the standard booking product as the duration is always one night.
Overwriting this duration fetching function acts as a compatibility layer. It is possible to create a and set parameters for a booking product. Later it is possible to change the product type to accommodation. Some of the fields are hidden but still remain set. This prevents now
hidden duration field from having an effect on the calculation.

Fixes #185 .

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

