### PR TITLE
Match function declarations closes #215

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 1.1.7 - 2019-xx-xx =
+* Fix - Mismatch function declaration causing PHP warnings.
+
 = 1.1.6 - 2019-04-17 =
 * Remove - partially booked days styling.
 * Tweak - WC tested up to 3.6

--- a/includes/class-wc-product-accommodation-booking.php
+++ b/includes/class-wc-product-accommodation-booking.php
@@ -197,10 +197,11 @@ class WC_Product_Accommodation_Booking extends WC_Product_Booking {
 	 * @param array $intervals
 	 * @param int   $resource_id
 	 * @param array $booked
+	 * @param bool  $get_past_times
 	 *
 	 * @return array
 	 */
-	public function get_blocks_in_range( $start_date, $end_date, $intervals = array(), $resource_id = 0, $booked = array() ) {
+	public function get_blocks_in_range( $start_date, $end_date, $intervals = array(), $resource_id = 0, $booked = array(), $get_past_times = false ) {
 
 		$blocks_in_range = $this->get_blocks_in_range_for_day( $start_date, $end_date, $resource_id, $booked );
 


### PR DESCRIPTION
Fixes #215 

#### Changes proposed in this Pull Request:
* Fix - Mismatch function declaration causing PHP warnings.

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

