### PR TITLE
Fix multiply addon price by nights opiton

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 1.1.10 - 2019-**-** =
+* Fix - Integration with WooCommerce Product Add-ons.
+
 = 1.1.9 - 2019-08-09 =
 * Tweak - Update deprecated calls to WC_Bookings_Controller::get_all_existing_bookings since Bookings 1.15.0.
 * Tweak - WC tested up to 3.7.

--- a/includes/integrations/class-wc-accommodation-booking-addons.php
+++ b/includes/integrations/class-wc-accommodation-booking-addons.php
@@ -13,8 +13,8 @@ class WC_Accommodation_Booking_Addons {
 	public function __construct() {
 		add_filter( 'woocommerce_product_addons_show_grand_total', array( $this, 'addons_show_grand_total' ), 20, 2 );
 		add_action( 'woocommerce_product_addons_panel_before_options', array( $this, 'addon_options' ), 20, 3 );
-		add_filter( 'woocommerce_product_addons_save_data', array( $this, 'save_addon_options' ), 25, 2 );
 		add_filter( 'woocommerce_product_addons_adjust_price', array( $this, 'disable_product_add_on_price_adjustment' ), 20, 2 );
+		add_filter( 'woocommerce_product_addon_cart_item_data', array( $this, 'addon_price' ), 25, 4 );
 	}
 
 	/**
@@ -35,49 +35,53 @@ class WC_Accommodation_Booking_Addons {
 	}
 
 	/**
-	 * Show options
+	 * Show same options as bookings integration now.
+	 * Only difference is the product type we are targeting.
 	 */
 	public function addon_options( $post, $addon, $loop ) {
-		$css_classes = '';
-		
+		$css_classes = 'show_if_accommodation-booking';
+
 		if ( is_object( $post ) ) {
 			$product = wc_get_product( $post->ID );
-			$css_classes .= 'show_if_accommodation-booking';
 			if ( 'accommodation-booking' !== $product->get_type() ) {
 				$css_classes .= ' hide_initial_booking_addon_options';
 			}
-		}
-
-		if ( version_compare( WC_PRODUCT_ADDONS_VERSION, '3.0', '<' ) ) {
-		?>
-		<tr class="<?php echo esc_attr( $css_classes ); ?>">
-			<td class="addon_wc_booking_block_qty_multiplier addon_required" width="50%">
-				<label for="addon_wc_accommodation_booking_block_qty_multiplier_<?php echo $loop; ?>"><?php esc_html_e( 'Bookings: Multiply cost by number of nights', 'woocommerce-accommodation-bookings' ); ?></label>
-
-				<input type="checkbox" id="addon_wc_accommodation_booking_block_qty_multiplier_<?php echo $loop; ?>" name="addon_wc_accommodation_booking_block_qty_multiplier[<?php echo $loop; ?>]" <?php checked( ! empty( $addon['wc_accommodation_booking_block_qty_multiplier'] ), true ) ?> />
-			</td>
-		</tr>
-		<?php
 		} else {
-		?>
-		<div class="<?php echo esc_attr( $css_classes ); ?>">
-			<div class="addon_wc_accommodation_booking_block_qty_multiplier">
-				<label for="addon_wc_accommodation_booking_block_qty_multiplier_<?php echo $loop; ?>">
-					<input type="checkbox" id="addon_wc_accommodation_booking_block_qty_multiplier_<?php echo $loop; ?>" name="addon_wc_accommodation_booking_block_qty_multiplier[<?php echo $loop; ?>]" <?php checked( ! empty( $addon['wc_accommodation_booking_block_qty_multiplier'] ), true ); ?> /> <?php esc_html_e( 'Bookings: Multiply cost by number of nights', 'woocommerce-accommodation-bookings' ); ?>
-				</label>
-			</div>
-		</div>
-		<?php
+			$css_classes .= ' hide_initial_booking_addon_options';
 		}
-	}
 
-	/**
-	 * Save options
-	 */
-	public function save_addon_options( $data, $i ) {	
-		$data['wc_accommodation_booking_block_qty_multiplier'] = isset( $_POST['addon_wc_accommodation_booking_block_qty_multiplier'][ $i ] ) ? 1 : 0;
-		
-		return $data;
+		if ( defined( 'WC_PRODUCT_ADDONS_VERSION' ) && version_compare( WC_PRODUCT_ADDONS_VERSION, '3.0', '<' ) ) {
+			?>
+			<tr class="<?php echo esc_attr( $css_classes ); ?>">
+				<td class="addon_wc_booking_person_qty_multiplier addon_required" width="50%">
+					<label for="addon_wc_booking_accommodation_person_qty_multiplier_<?php echo esc_attr( $loop ); ?>"><?php esc_html_e( 'Bookings: Multiply cost by person count', 'woocommerce-bookings' ); ?></label>
+					<input type="checkbox" id="addon_wc_booking_accommodation_person_qty_multiplier_<?php echo esc_attr( $loop ); ?>" name="addon_wc_booking_person_qty_multiplier[<?php echo esc_attr( $loop ); ?>]" <?php checked( ! empty( $addon['wc_booking_person_qty_multiplier'] ), true ); ?> />
+				</td>
+				<td class="addon_wc_booking_block_qty_multiplier addon_required" width="50%">
+					<label for="addon_wc_booking_accommodation_block_qty_multiplier_<?php echo esc_attr( $loop ); ?>"><?php esc_html_e( 'Bookings: Multiply cost by block count', 'woocommerce-bookings' ); ?></label>
+					<input type="checkbox" id="addon_wc_booking_accommodation_block_qty_multiplier_<?php echo esc_attr( $loop ); ?>" name="addon_wc_booking_block_qty_multiplier[<?php echo esc_attr( $loop ); ?>]" <?php checked( ! empty( $addon['wc_booking_block_qty_multiplier'] ) || ! empty( $addon['wc_accommodation_booking_block_qty_multiplier'] ), true ); ?> />
+				</td>
+			</tr>
+			<?php
+		} else {
+			?>
+			<div class="<?php echo esc_attr( $css_classes ); ?>">
+				<div class="addon_wc_booking_person_qty_multiplier">
+					<label for="addon_wc_booking_accommodation_person_qty_multiplier_<?php echo esc_attr( $loop ); ?>">
+						<input type="checkbox" id="addon_wc_booking_accommodation_person_qty_multiplier_<?php echo esc_attr( $loop ); ?>" name="addon_wc_booking_person_qty_multiplier[<?php echo esc_attr( $loop ); ?>]" <?php checked( ! empty( $addon['wc_booking_person_qty_multiplier'] ), true ); ?> /> <?php esc_html_e( 'Bookings: Multiply cost by person count', 'woocommerce-accommodation-bookings' ); ?>
+						<?php echo wc_help_tip( __( 'Only applies to options which use quantity based prices.', 'woocommerce-accommodation-bookings' ) ); ?>
+					</label>
+				</div>
+
+				<div class="addon_wc_booking_block_qty_multiplier">
+					<label for="addon_wc_booking_accommodation_block_qty_multiplier_<?php echo esc_attr( $loop ); ?>">
+						<input type="checkbox" id="addon_wc_booking_accommodation_block_qty_multiplier_<?php echo esc_attr( $loop ); ?>" name="addon_wc_booking_block_qty_multiplier[<?php echo esc_attr( $loop ); ?>]" <?php checked( ! empty( $addon['wc_booking_block_qty_multiplier'] ) || ! empty( $addon['wc_accommodation_booking_block_qty_multiplier'] ), true ); ?> /> <?php esc_html_e( 'Bookings: Multiply cost number of nights', 'woocommerce-accommodation-bookings' ); ?>
+						<?php echo wc_help_tip( __( 'Only applies to options which use quantity based prices.', 'woocommerce-accommodation-bookings' ) ); ?>
+					</label>
+				</div>
+			</div>
+			<?php
+		}
 	}
 
 	/**
@@ -93,6 +97,23 @@ class WC_Accommodation_Booking_Addons {
 			return false;
 		}
 		return $bool;
+	}
+
+	/**
+	 * Change addon price based on settings
+	 * @return float
+	 */
+	public function addon_price( $cart_item_data, $addon, $product_id, $post_data ) {
+
+		// Option `wc_accommodation_booking_block_qty_multiplier` is deprecated and identical to booking's `wc_booking_block_qty_multiplier`.
+		foreach ( $cart_item_data as $key => $data ) {
+			if ( ! empty( $addon['wc_accommodation_booking_block_qty_multiplier'] ) ) {
+				// Intentionally using a different key as these mean the same thing, and we will not need to duplicate code here.
+				$cart_item_data[ $key ]['wc_booking_block_qty_multiplier'] = 1;
+			}
+		}
+
+		return $cart_item_data;
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-product-addons/issues/489
and https://github.com/woocommerce/woocommerce-product-addons/issues/489
and https://github.com/woocommerce/woocommerce-product-addons/issues/485


#### Changes proposed in this Pull Request:
- Stop having accommodations duplicate code of the bookings integration.
- Option "Multiply cost number of nights" is the same as "Multiply cost by block count" but it'll just be renamed in accommodations.
- So now these options actually work
- Also fix displaying the options correctly before product is created.

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

