### PR TITLE
Add wp_org_slug for .org release support in woocommerce-extension-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
   "engines": {
     "node": ">=8.9.3",
     "npm": ">=5.5.1"
+  },
+  "config": {
+    "wp_org_slug": "woocommerce-accommodation-bookings"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-extension-release/issues/22

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

