### PR TITLE
Fix Overlapping Rates

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 1.1.12 - 2019-xx-xx =
+* Fix - Overlapping rate calculation is incorrect.
+
 = 1.1.11 - 2019-11-04 =
 * Tweak - WC tested up to 3.8.
 

--- a/includes/class-wc-accommodation-booking.php
+++ b/includes/class-wc-accommodation-booking.php
@@ -23,6 +23,7 @@ class WC_Accommodation_Booking {
 
 		add_action( 'woocommerce_new_booking', array( $this, 'update_start_end_time' ) );
 		add_filter( 'woocommerce_data_stores', array( $this, 'register_data_stores' ), 10 );
+		add_filter( 'woocommerce_bookings_apply_multiple_rules_per_block', '__return_false' );
 	}
 
 	/**

--- a/includes/class-wc-accommodation-booking.php
+++ b/includes/class-wc-accommodation-booking.php
@@ -23,7 +23,28 @@ class WC_Accommodation_Booking {
 
 		add_action( 'woocommerce_new_booking', array( $this, 'update_start_end_time' ) );
 		add_filter( 'woocommerce_data_stores', array( $this, 'register_data_stores' ), 10 );
-		add_filter( 'woocommerce_bookings_apply_multiple_rules_per_block', '__return_false' );
+		add_filter( 'woocommerce_bookings_apply_multiple_rules_per_block', array( $this, 'disable_overlapping_rates' ), 10, 2 );
+	}
+
+	/**
+	 * Apply only one rate modifier to any given accomodation block.
+	 *
+	 * Rate rules for accomodation bookings define the absolute accomodation
+	 * rate for a block, so it does not make sense to apply multiple concurrent
+	 * rates. This hook will cause the rate calculation loop to exit after the
+	 * first applicable rate rule modifies the block cost.
+	 *
+	 * @since 1.1.12
+	 *
+	 * @param  bool               $enable_overlapping_rates
+	 * @param  WC_Product_Booking $product
+	 * @return array
+	 */
+	public function disable_overlapping_rates( $enable_overlapping_rates, $product ) {
+		if ( ! is_a( $product, 'WC_Product_Accommodation_Booking' ) ) {
+			return $enable_overlapping_rates;
+		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #209

#209 occurs because accommodation-bookings provides a simplified UX for modifying accommodations rates, which is hiding how Bookings is actually applying rate adjustments.

For Accommodation products, if a special rate is required, you directly enter that rate like this:
<img width="1534" alt="image" src="https://user-images.githubusercontent.com/6209518/70827780-d7284400-1d9e-11ea-8fbb-c161356ab0c3.png">
Which results in $1000/night for every night, except on December 23rd/24th, the accommodation rate is $100/night.

Behind the scenes, though, this rate is saved like this for the core Booking code: 
<img width="1683" alt="image" src="https://user-images.githubusercontent.com/6209518/70827908-1ce50c80-1d9f-11ea-9f60-496e59c9b385.png">
So, the block cost is $1000, but we're subtracting $900 on those dates. The result is still $100/night.

Unfortunately, you end up with some really confusing behavior (hence #209) if you have multiple rates applying to the same day, because core Bookings is actually adding all of these rate adjustments together. So, if I have overlapping accommodation product rates of $10, and $100 like so:
<img width="1364" alt="image" src="https://user-images.githubusercontent.com/6209518/70828525-61bd7300-1da0-11ea-9ebe-8d27859c146d.png">

the core Bookings code will actually see this as -$900 and -$990 adjustment:
<img width="1417" alt="image" src="https://user-images.githubusercontent.com/6209518/70828944-4e5ed780-1da1-11ea-9bdf-c7d35d632cf8.png">


The above setup will end up -$1890 being applied to the block cost on December, the 23rd.


To make this behave more sensibly, this PR (along with Bookings PR https://github.com/woocommerce/woocommerce-bookings/pull/2767) causes only one rate rule to apply to any accommodation product block, so with the above setup, the room would be $10 on the 23rd. 


#### Changes proposed in this Pull Request:
Adds filter hook for an unreleased Bookings filter `woocommerce_bookings_apply_multiple_rules_per_block` (adding on https://github.com/woocommerce/woocommerce-bookings/pull/2767)
This results in only one rate rule being applied to any one block, so if two or more rates apply to the same block, then only the first one in the list will modify the rate.

#### Testing instructions:
- Install Booking PR  https://github.com/woocommerce/woocommerce-bookings/pull/2767
- Create an accommodation product with rate rules that have overlapping dates
- Confirm that only the first rate rule is a applied to a block for dates where overlapping rules apply
- Confirm that other dates have the correct rules

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

