### PR TITLE
Remove check for check in dates as those dates should be unavailable …

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 1.1.13 - 2020-xx-xx =
 * Fix - Proper escaping of some attributes.
+* Fix - Ensure unavailable dates are shown to be unavailable in calendar.
 
 = 1.1.12 - 2020-01-15 =
 * Fix - Overlapping rate calculation is incorrect.

--- a/includes/class-wc-accommodation-booking-date-picker.php
+++ b/includes/class-wc-accommodation-booking-date-picker.php
@@ -97,7 +97,7 @@ class WC_Accommodation_Booking_Date_Picker {
 		$check_in_out_times = $this->get_check_in_and_out_times( $product );
 
 		// Go through each checkin and checkout days and mark them as partially booked.
-		foreach ( array( 'in', 'out' ) as $which ) {
+		foreach ( array( 'out' ) as $which ) {
 			foreach ( $check_in_out_times[ $which ] as $resource_id => $times ) {
 				foreach ( $times as $time ) {
 					$day = date( 'Y-n-j', $time );
@@ -107,7 +107,7 @@ class WC_Accommodation_Booking_Date_Picker {
 					}
 
 					$check_in_time = $product->get_check_times( 'in' );
-					if( 'in' === $which ){
+					if ( 'in' === $which ) {
 						$check_time = strtotime( '-1 day ' . $check_in_time , $time );
 					} else {
 						$check_time = strtotime( $check_in_time, $time );

--- a/readme.txt
+++ b/readme.txt
@@ -38,5 +38,6 @@ If the prices shown on the product do not match the prices defined in the dashbo
 
 = 1.1.13 - 2020-xx-xx =
 * Fix - Proper escaping of some attributes.
+* Fix - Ensure unavailable dates are shown to be unavailable in calendar.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-accommodation-bookings/master/changelog.txt).


### PR DESCRIPTION
…closes #235

Fixes #235

#### Changes proposed in this Pull Request:
* Fix - Ensure unavailable dates are shown to be unavailable in calendar.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

