### PR TITLE
Fix Person types are not copied over when duplicating an existing acc…

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 1.1.14 2020-xx-xx =
+* Fix - Person types are not copied over when duplicating an existing accommodations product.
+
 = 1.1.13 2020-02-04 =
 * Fix - Proper escaping of some attributes.
 * Fix - Ensure unavailable dates are shown to be unavailable in calendar.

--- a/includes/admin/class-wc-accommodation-booking-admin-panels.php
+++ b/includes/admin/class-wc-accommodation-booking-admin-panels.php
@@ -12,8 +12,7 @@ class WC_Accommodation_Booking_Admin_Panels {
 	 */
 	public function __construct() {
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_styles_and_scripts' ) );
-
-		add_filter( 'product_type_selector' , array( $this, 'product_type_selector' ) );
+		add_filter( 'product_type_selector', array( $this, 'product_type_selector' ) );
 		add_filter( 'product_type_options', array( $this, 'product_type_options' ), 15 );
 
 		if ( version_compare( WC_VERSION, '3.0', '<' ) ) {

--- a/includes/class-wc-accommodation-bookings-plugin.php
+++ b/includes/class-wc-accommodation-bookings-plugin.php
@@ -49,6 +49,26 @@ class WC_Accommodation_Bookings_Plugin {
 	}
 
 	/**
+	 * Handles additional tasks when product is duplicated.
+	 *
+	 * @since 1.1.14
+	 * @param  WC_Product $new_product Duplicated product.
+	 * @param  WC_Product $product     Original product.
+	 * @return void
+	 */
+	public function woocommerce_duplicate_product( $new_product, $product ) {
+		if ( $product->is_type( 'accommodation-booking' ) ) {
+			// Clone and re-save person types.
+			foreach ( $product->get_person_types() as $person_type ) {
+				$dupe_person_type = clone $person_type;
+				$dupe_person_type->set_id( 0 );
+				$dupe_person_type->set_parent_id( $new_product->get_id() );
+				$dupe_person_type->save();
+			}
+		}
+	}
+
+	/**
 	 * Define plugin's constants.
 	 *
 	 * @return void
@@ -80,6 +100,7 @@ class WC_Accommodation_Bookings_Plugin {
 
 		if ( is_admin() ) {
 			add_action( 'init', array( $this, 'admin_includes' ), 10 );
+			add_action( 'woocommerce_product_duplicate', array( $this, 'woocommerce_duplicate_product' ), 10, 2 );
 		}
 
 		add_action( 'shutdown', array( $this, 'install' ) );


### PR DESCRIPTION
…ommodations product closes #212

Fixes #212

#### Changes proposed in this Pull Request:
* Fix - Person types are not copied over when duplicating an existing accommodations product.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

