### PR TITLE
Fix missing translation for resource duration display.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 1.1.14 2020-xx-xx =
 * Fix - Person types are not copied over when duplicating an existing accommodations product.
+* Fix - Fix missing translation for resource duration display.
 
 = 1.1.13 2020-02-04 =
 * Fix - Proper escaping of some attributes.

--- a/includes/class-wc-accommodation-booking.php
+++ b/includes/class-wc-accommodation-booking.php
@@ -168,7 +168,7 @@ class WC_Accommodation_Booking {
 	/**
 	 * Updates resource duration display string when duration unit is 'night'.
 	 *
-	 * @since 1.1.14
+	 * @since 1.1.15
 	 *
 	 * @param string $duration_display Duration to display.
 	 * @param object $product          The product we are working with.

--- a/includes/class-wc-accommodation-booking.php
+++ b/includes/class-wc-accommodation-booking.php
@@ -24,7 +24,7 @@ class WC_Accommodation_Booking {
 		add_action( 'woocommerce_new_booking', array( $this, 'update_start_end_time' ) );
 		add_filter( 'woocommerce_data_stores', array( $this, 'register_data_stores' ), 10 );
 		add_filter( 'woocommerce_bookings_apply_multiple_rules_per_block', array( $this, 'disable_overlapping_rates' ), 10, 2 );
-		add_filter( 'woocommerce_bookings_resource_duration_display_string', array( $this, 'accommodation_resource_duration_display_string' ), 10, 2 );
+		add_filter( 'woocommerce_bookings_resource_duration_display_string', array( $this, 'filter_resource_duration_display_string' ), 10, 2 );
 	}
 
 	/**
@@ -175,13 +175,12 @@ class WC_Accommodation_Booking {
 	 *
 	 * @return string $duration_display Duration to display.
 	 */
-	public function accommodation_resource_duration_display_string( $duration_display, $product ) {
-		if ( ! $product || ( 'night' !== $product->get_duration_unit() ) ) {
+	public function filter_resource_duration_display_string( $duration_display, $product ) {
+		if ( ! is_a( $product, 'WC_Product_Accommodation_Booking' ) || ( 'night' !== $product->get_duration_unit() ) ) {
 			return $duration_display;
 		}
 
 		return __( 'night', 'woocommerce-accommodation-bookings' );
-
 	}
 
 	/**

--- a/includes/class-wc-accommodation-booking.php
+++ b/includes/class-wc-accommodation-booking.php
@@ -24,6 +24,7 @@ class WC_Accommodation_Booking {
 		add_action( 'woocommerce_new_booking', array( $this, 'update_start_end_time' ) );
 		add_filter( 'woocommerce_data_stores', array( $this, 'register_data_stores' ), 10 );
 		add_filter( 'woocommerce_bookings_apply_multiple_rules_per_block', array( $this, 'disable_overlapping_rates' ), 10, 2 );
+		add_filter( 'woocommerce_bookings_resource_duration_display_string', array( $this, 'accommodation_resource_duration_display_string' ), 10, 2 );
 	}
 
 	/**
@@ -165,6 +166,25 @@ class WC_Accommodation_Booking {
 	}
 
 	/**
+	 * Updates resource duration display string when duration unit is 'night'.
+	 *
+	 * @since 1.1.14
+	 *
+	 * @param string $duration_display Duration to display.
+	 * @param object $product          The product we are working with.
+	 *
+	 * @return string $duration_display Duration to display.
+	 */
+	public function accommodation_resource_duration_display_string( $duration_display, $product ) {
+		if ( ! $product || ( 'night' !== $product->get_duration_unit() ) ) {
+			return $duration_display;
+		}
+
+		return __( 'night', 'woocommerce-accommodation-bookings' );
+
+	}
+
+	/**
 	 * Update the time of a given datetime.
 	 *
 	 * @param string $datetime Date time without separator (YmdHis)
@@ -182,6 +202,7 @@ class WC_Accommodation_Booking {
 
 		return substr( $datetime, 0, 8 ) . $time;
 	}
+
 }
 
 new WC_Accommodation_Booking;


### PR DESCRIPTION
Fixes #221  when used with https://github.com/woocommerce/woocommerce-bookings/tree/fix/issue-221

#### Changes proposed in this Pull Request:
Uses new filter in Bookings 'woocommerce_bookings_resource_duration_display_string' to display 'night' resource duration.

How to test:
1. Activate Bookings with the new filter (Branch fix/issue-221) and Accommodation bookings.
2. Build the plugin and translate 'night' into Spanish (Ex: Using Loco Translate)
3. Create an accommodation product (with a standard room rate).
4. Add customer selected resources to the product with a block cost.
<img width="1197" alt="AccomodationResource" src="https://user-images.githubusercontent.com/8002881/75281687-5097d600-57d5-11ea-8ff4-954495dec909.png">

5. View the product
6. Change the site language to Spanish, view the product and check the resource duration is translated.

![AccomodationDuration](https://user-images.githubusercontent.com/8002881/75281860-a40a2400-57d5-11ea-8dbc-da80c01bde4d.png)

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

