### PR TITLE
Add Basic Unit tests suite.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 1.1.15 - 2020-**-** =
 * Fix - Fix missing translation for resource duration display.
+* Add - Add basic unit tests suite.
 
 = 1.1.14 - 2020-02-26 =
 * Fix - Person types are not copied over when duplicating an existing accommodations product.

--- a/composer.json
+++ b/composer.json
@@ -8,5 +8,9 @@
         "exclude": [
             "!/assets"
         ]
+    },
+    "require-dev": {
+		"phpunit/phpunit": "^9.0",
+        "10up/wp_mock": "0.4.2"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         ]
     },
     "require-dev": {
-		"phpunit/phpunit": "^8.0",
+        "phpunit/phpunit": "^8.0",
         "10up/wp_mock": "0.4.2"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         ]
     },
     "require-dev": {
-		"phpunit/phpunit": "^9.0",
+		"phpunit/phpunit": "^8.0",
         "10up/wp_mock": "0.4.2"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+		bootstrap="tests/phpunit/bootstrap.php"
+		backupGlobals="false"
+		colors="true"
+		convertErrorsToExceptions="true"
+		convertNoticesToExceptions="true"
+		convertWarningsToExceptions="true"
+		verbose="true"
+>
+	<testsuites>
+		<testsuite name="WC Accommodation Bookings">
+			<directory prefix="test-" suffix=".php">./tests/phpunit</directory>
+		</testsuite>
+	</testsuites>
+    <php>
+        <ini name="display_errors" value="On" />
+        <ini name="display_startup_errors" value="On" />
+    </php>
+</phpunit>

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * The bootstrap file for PHPUnit tests for the WooCommerce Accommodation Bookings plugin.
+ * Starts up WP_Mock and requires the files needed for testing.
+ */
+
+$plugin_dir = dirname( dirname( dirname( __FILE__ ) ) ) . '/';
+// First we need to load the composer autoloader so we can use WP Mock.
+require_once $plugin_dir . '/vendor/autoload.php';
+// Now call the bootstrap method of WP Mock.
+WP_Mock::bootstrap();
+
+define( 'ABSPATH', dirname( dirname( dirname( dirname( dirname( __FILE__ ) ) ) ) ) . '/' );
+define( 'WC_VERSION', 3.9 );
+
+require __DIR__ . '/../../includes/class-wc-accommodation-booking.php';

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -10,7 +10,6 @@ require_once $plugin_dir . '/vendor/autoload.php';
 // Now call the bootstrap method of WP Mock.
 WP_Mock::bootstrap();
 
-define( 'ABSPATH', dirname( dirname( dirname( dirname( dirname( __FILE__ ) ) ) ) ) . '/' );
 define( 'WC_VERSION', 3.9 );
 
 require __DIR__ . '/../../includes/class-wc-accommodation-booking.php';

--- a/tests/phpunit/test-class-wc-accommodation-booking.php
+++ b/tests/phpunit/test-class-wc-accommodation-booking.php
@@ -34,12 +34,12 @@ class TestWCAccommodationBooking extends TestCase {
 		$accommodation_booking = new WC_Accommodation_Booking();
 		$this->assertInstanceOf( 'WC_Accommodation_Booking', $accommodation_booking );
 	}
-		/**
+	/**
 	 * @test Test function changes duration display for accommodation bookings and duration 'night'.
 	 * Also tests there are no changes on duration display for other product types
-	 * 
+	 *
 	 * @dataProvider FilterResourceDurationDisplayStringProvider
-	 * @param array $args        Test input data.
+	 * @param array $product        Test input data.
 	 * @param array $expected    Test expected result.
 	 *
 	 * @since 1.1.15
@@ -60,7 +60,7 @@ class TestWCAccommodationBooking extends TestCase {
 	/**
 	 * @return array
 	 */
-	public function FilterResourceDurationDisplayStringProvider(){
+	public function FilterResourceDurationDisplayStringProvider() {
 		$mock_product_accommodation_booking = \Mockery::mock( 'overload:WC_Product_Accommodation_Booking' );
 		$mock_product_accommodation_booking
 			->shouldReceive( 'get_duration_unit' )
@@ -77,7 +77,7 @@ class TestWCAccommodationBooking extends TestCase {
 			[
 				$mock_product_booking,
 				'durationString',
-			],			
+			],
 		];
 	}
 }

--- a/tests/phpunit/test-class-wc-accommodation-booking.php
+++ b/tests/phpunit/test-class-wc-accommodation-booking.php
@@ -34,4 +34,50 @@ class TestWCAccommodationBooking extends TestCase {
 		$accommodation_booking = new WC_Accommodation_Booking();
 		$this->assertInstanceOf( 'WC_Accommodation_Booking', $accommodation_booking );
 	}
+		/**
+	 * @test Test function changes duration display for accommodation bookings and duration 'night'.
+	 * Also tests there are no changes on duration display for other product types
+	 * 
+	 * @dataProvider FilterResourceDurationDisplayStringProvider
+	 * @param array $args        Test input data.
+	 * @param array $expected    Test expected result.
+	 *
+	 * @since 1.1.15
+	 */
+	public function testFilterResourceDurationDisplayString( $product, $expected ) {
+		\WP_Mock::userFunction(
+			'__',
+			array(
+				'args'   => array( 'night', 'woocommerce-accommodation-bookings' ),
+				'return' => 'nightTranslationString',
+			)
+		);
+		$accommodation_booking = new \WC_Accommodation_Booking();
+		$duration_display      = $accommodation_booking->filter_resource_duration_display_string( $product->get_duration_unit(), $product );
+		$this->assertEquals( $expected, $duration_display );
+	}
+
+	/**
+	 * @return array
+	 */
+	public function FilterResourceDurationDisplayStringProvider(){
+		$mock_product_accommodation_booking = \Mockery::mock( 'overload:WC_Product_Accommodation_Booking' );
+		$mock_product_accommodation_booking
+			->shouldReceive( 'get_duration_unit' )
+			->andReturn( 'night' );
+		$mock_product_booking = \Mockery::mock( 'overload:WC_Product_Booking' );
+		$mock_product_booking
+			->shouldReceive( 'get_duration_unit' )
+			->andReturn( 'durationString' );
+		return [
+			[
+				$mock_product_accommodation_booking,
+				'nightTranslationString',
+			],
+			[
+				$mock_product_booking,
+				'durationString',
+			],			
+		];
+	}
 }

--- a/tests/phpunit/test-class-wc-accommodation-booking.php
+++ b/tests/phpunit/test-class-wc-accommodation-booking.php
@@ -1,0 +1,37 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The TestWCAccommodationBookin class tests the functions on file class-wc-accommodation-booking.php.
+ */
+class TestWCAccommodationBooking extends TestCase {
+	/**
+	 * Set up required options before each test.
+	 *
+	 * @since 1.1.15
+	 *
+	 * @return void
+	 */
+	public function setUp():void {
+		\WP_Mock::setUp();
+	}
+	/**
+	 * Remove required options after each test.
+	 *
+	 * @since 1.1.15
+	 *
+	 * @return void
+	 */
+	public function tearDown():void {
+		\WP_Mock::tearDown();
+	}
+
+	/** @test - Test that instantiation of the class is working.
+	 **/
+	public function testIsAnInstanceOfWCAccommodationBooking() {
+
+		$accommodation_booking = new WC_Accommodation_Booking();
+		$this->assertInstanceOf( 'WC_Accommodation_Booking', $accommodation_booking );
+	}
+}


### PR DESCRIPTION
Fixes #244  .

#### Changes proposed in this Pull Request:

Basic skeleton to add unit/integration tests.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

