### PR TITLE
Fix issue #252, set width:auto on 'Restrict start days?' label

### DIFF
--- a/includes/admin/views/html-accommodation-booking-availability.php
+++ b/includes/admin/views/html-accommodation-booking-availability.php
@@ -72,7 +72,7 @@
 					for ( $i=0;  $i < 7;  $i++) { 
 						?>
 							<td>
-								<label class="checkbox" for="_wc_accommodation_booking_restricted_days[<?php echo $i; ?>]"><?php echo $weekdays[ $i ]; ?>&nbsp;</label>
+								<label class="checkbox" for="_wc_accommodation_booking_restricted_days[<?php echo $i; ?>]" style="width: auto;"><?php echo $weekdays[ $i ]; ?>&nbsp;</label>
 								<input type="checkbox" class="checkbox" name="_wc_accommodation_booking_restricted_days[<?php echo $i; ?>]" id="_wc_accommodation_booking_restricted_days[<?php echo $i; ?>]" value="<?php echo $i; ?>" <?php checked( $restricted_days[ $i ], $i ); ?>>
 							</td>
 						<?php


### PR DESCRIPTION
Add auto width for the 'Restrict start days?' field in product settings.

### Changes proposed in this Pull Request:

Set `style="width: auto;"` on <label>, which is consistent with the same field set in WooCommerce Bookings.

Closes #252 

### How to test the changes in this Pull Request:

1. Create an 'Accommodation product'
2. Go to the 'Availability' tab
3. Zoom your browser to at least 110%
4. See that all days are still visible (M-F)

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
