### PR TITLE
Use time for transient to skip autoload

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 1.1.21 - 2020-xx-xx =
+* Fix - Use time for transient to skip autoload.
+
 = 1.1.20 - 2020-08-25 =
 * Fix - Do not rount cost values in range typas in Rates section.
 

--- a/includes/class-wc-product-accommodation-booking.php
+++ b/includes/class-wc-product-accommodation-booking.php
@@ -300,7 +300,7 @@ class WC_Product_Accommodation_Booking extends WC_Product_Booking {
 			}
 
 
-			set_transient( $transient_name, $available_slots );
+			set_transient( $transient_name, $available_slots, YEAR_IN_SECONDS );
 		}
 
 		return $available_slots;


### PR DESCRIPTION
Fixes #222.

Also accompanied by https://github.com/woocommerce/woocommerce-bookings/commit/8a5438dd92fab69b3dd2f5f921ed80d507c15ac2