### PR TITLE
Change message to be accurate with functionality.

### DIFF
--- a/includes/admin/views/html-accommodation-booking-availability.php
+++ b/includes/admin/views/html-accommodation-booking-availability.php
@@ -46,8 +46,8 @@
 					array(
 						'id'          => '_wc_accommodation_booking_has_restricted_days',
 						'value'       => $bookable_product->has_restricted_days( 'edit' ) ? 'yes' : 'no',
-						'label'       => __( 'Restrict start days?', 'woocommerce-bookings' ),
-						'description' => __( 'Restrict bookings so that they can only start on certain days of the week. Does not affect availability.', 'woocommerce-bookings' ),
+						'label'       => __( 'Restrict selectable days?', 'woocommerce-accommodation-bookings' ),
+						'description' => __( 'Restrict the days of the week that are able to be selected on the calendar; this will not affect your availability.', 'woocommerce-accommodation-bookings' ),
 					)
 				);
 		?>


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We want to change the message for setting for start days to selectable days because that's what the function actually does. We cannot change the underlying functionality instead to be backward compatible, and also to stay consistent with Bookings plugin.

Closes #227.

### How to test the changes in this Pull Request:

1. Create an accommodation bookings product, go to the "Availability" tab.
2. Make sure the text for setting start days is changed to selectable days.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Change start days settings label to selectable days to be more accurate with functionality.
