### PR TITLE
Fix/290 `float` used to convert blank cost to `0`

### DIFF
--- a/includes/admin/class-wc-accommodation-booking-admin-panels.php
+++ b/includes/admin/class-wc-accommodation-booking-admin-panels.php
@@ -258,7 +258,7 @@ class WC_Accommodation_Booking_Admin_Panels {
 				$resource_base_costs[ $resource_id ]  = wc_clean( $resource_base_cost[ $i ] );
 				$resource_block_costs[ $resource_id ] = wc_clean( $resource_block_cost[ $i ] );
 
-				if ( ( $resource_base_cost[ $i ] + $resource_block_cost[ $i ] ) > 0 ) {
+				if ( ( (float) $resource_base_cost[ $i ] + (float) $resource_block_cost[ $i ] ) > 0 ) {
 					$has_additional_costs = true;
 				}
 			}


### PR DESCRIPTION
### All Submissions:

* [ ] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR uses float type to convert blank string additions (string + string) to be (0 + 0).

Closes #290.

### How to test the changes in this Pull Request:

1. Create an accommodation product.
2. Tick the “Has Resources” checkbox.
3. Add some resources.
4. Make sure to keep the base cost and/or block cost empty.
5. Save the product.
6. Product should be saved without any errors.

### Other information:

* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Fatal error with PHP 8.0 when Base Cost/Block Cost is empty.
