### PR TITLE
Tweak/292 Bump tested up to WordPress 6.0

### DIFF
--- a/includes/admin/class-wc-accommodation-booking-admin-product-settings.php
+++ b/includes/admin/class-wc-accommodation-booking-admin-product-settings.php
@@ -211,7 +211,7 @@ class WC_Accommodation_Booking_Admin_Product_Settings extends WC_Settings_API {
 		$field_key    = $this->get_field_key( $key );
 		$type         = $value['type'];
 		$option_value = get_option( $this->plugin_id . $this->id . '_settings' );
-		$option_value = $option_value[ $key ];
+		$option_value = isset( $option_value[ $key ] ) ? $option_value[ $key ] : '';
 		ob_start();
 
 		?><tr valign="top">

--- a/woocommerce-accommodation-bookings.php
+++ b/woocommerce-accommodation-bookings.php
@@ -8,7 +8,7 @@
  * Author URI: https://woocommerce.com
  * Text Domain: woocommerce-accommodation-bookings
  * Domain Path: /languages
- * Tested up to: 5.8
+ * Tested up to: 6.0
  * WC tested up to: 5.9
  * WC requires at least: 2.6
  *


### PR DESCRIPTION
### All Submissions:

* [ ] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- The plugin is tested with the WordPress development version (6.0-RC1-53361) and Twenty Twenty Two theme.
- Found PHP warnings on the Accommodation settings tab. The fix is applied in this PR.
- While testing found a Fatal error when the product is saved, this is already fixed in #291.

Closes #292.

### Tested cases:

- ✅  Works are expected When the number of nights is 1 to 3.
- ✅  Bookable product with Multiple Resources.
- ✅  Bookable product with slots “available” by default setting.
- ✅  Bookable product with slots “not-available” by default setting.
- ✅  Bookable product with Multiple persons.
- ✅  Accommodation bookings settings.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Bump tested up to WordPress version 6.0.
> Fix - PHP Warnings on the setting page.
