### PR TITLE
Fix/296 The `abs` string given issue fixed for PHP 8.0/8.1

### DIFF
--- a/includes/admin/views/html-accommodation-booking-rates-fields.php
+++ b/includes/admin/views/html-accommodation-booking-rates-fields.php
@@ -109,7 +109,7 @@
 		if ( ! empty( $rate['override_block'] ) ) {
 			echo $rate['override_block'];
 		} else if ( ! empty( $rate['modifier'] ) && isset( $rate['cost'] ) ) {
-			$base_cost = abs( get_post_meta( $post_id, '_wc_booking_base_cost', true ) );
+			$base_cost = abs( intval( get_post_meta( $post_id, '_wc_booking_base_cost', true ) ) );
 
 			if ( 'plus' == $rate['modifier'] ) {
 				echo $base_cost + $rate['cost'];


### PR DESCRIPTION
### All Submissions:

* [ ] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Used `intval` function to wrap the result of the post meta to fix the following error:

```
CRITICAL Uncaught TypeError: abs(): Argument #1 ($num) must be of type int|float, string given in /var/www/wooturnkey/public_html/sites/wp-1847562/wp-content/plugins/woocommerce-accommodation-bookings/includes/admin/views/html-accommodation-booking-rates-fields.php:112
```

Closes #296.

### How to test the changes in this Pull Request:

1. Install the latest versions of Bookings and Accommodation Bookings on a site with PHP 8/8.1
2. Add an Accommodation Bookings product
3. Go to Rates tab and add a range (Range of months for example)
4. Keep the Standard room rate empty, and also the cost as empty.
5. Update/Publish the product and check the Rates tab again

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed - PHP 8.0/8.1 Compatibility issue fixed: Critical error when cost in range is empty if Standard room rate is empty as well.
