### PR TITLE
Fix/298 The day turns green when fully booked

### DIFF
--- a/includes/class-wc-accommodation-booking-date-picker.php
+++ b/includes/class-wc-accommodation-booking-date-picker.php
@@ -114,6 +114,12 @@ class WC_Accommodation_Booking_Date_Picker {
 					}
 					$check = date("F j, Y, g:i a", $check_time );
 					// Check available blocks for resource. If some are available that means that the day is not fully booked.
+
+					// Skip if the $check_time is false.
+					if ( ! $check_time ) {
+						continue;
+					}
+
 					$not_fully_booked = $this->get_product_resource_available_blocks_on_time( $product, $resource_id, $check_time );
 					if( $not_fully_booked ) {
 						$booked_data_array = $this->move_day_from_fully_to_partially_booked( $booked_data_array, $resource_id, $day );


### PR DESCRIPTION
### All Submissions:

* [ ] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- This PR fixes the issue of a day not being turned red when fully booked.
- The issue was occurring when `$check_date` passed to the `get_product_resource_available_blocks_on_time()` function was `false`. That cause `$not_fully_booked` to be true and convert the fully_booked day as a partially_booked!
https://github.com/woocommerce/woocommerce-accommodation-bookings/blob/43f14cabe2f489a6ab2f9fe7df54e1e8e22a72ad/includes/class-wc-accommodation-booking-date-picker.php#L117
- This PR simply adds a new check which only allows the `$check_date` to pass when it's not `false`. That fixes the issue and stops converting fully_booked days to the partially_booked ones unnecessarily.

_As seen in this image: the 28th turns red_
![acom-issue-fixed](https://user-images.githubusercontent.com/25176325/177541071-d182a08f-980a-4cb5-9abd-8924b2693dc2.gif)

Closes #298.

### How to test the changes in this Pull Request:

1. Create an accommodation product.
2. Set "Number of rooms available" to "1".
3. Book (for example) the 28th and 29th of the month.
4. (28th is partially booked, so it should still have a green color)
5. Book (for example) the 27th and 28th of the month.
6. (the rest of the 28th is now booked too, so it should turn RED)

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> The day is green even if its fully booked!
