### PR TITLE
Override Booking date

### DIFF
--- a/includes/class-wc-accommodation-booking-cart-manager.php
+++ b/includes/class-wc-accommodation-booking-cart-manager.php
@@ -52,6 +52,14 @@ class WC_Accommodation_Booking_Cart_Manager {
 					'display' => '',
 				);
 			}
+
+			// This data was added by Woo Booking plugin, so we need to override.
+			foreach ( $other_data as $key => $data ) {
+				if ( 'Booking Date' === $data['name'] ) {
+					$other_data[ $key ]['value'] = date_i18n( wc_bookings_date_format(), get_post_datetime( $cart_item['booking']['_booking_id'] ) );
+					break;
+				}
+			}
 		}
 
 		return $other_data;


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changes proposed in this Pull Request:

Override Booking date for accommodation to show the actual date of booking instead of check-in date.

Closes #28 

### How to test the changes in this Pull Request:

1. Create a bookable accommodation
2. Book accommodation and proceed to the cart
3. In the cart page, the booking date should show the booking date instead of check-in date

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry

> Fix - Showing check-in date on the cart page instead of booking date.
