### PR TITLE
Fix/Bookings-2398 Sync Declaration of `get_blocks_in_range`

### DIFF
--- a/includes/class-wc-product-accommodation-booking.php
+++ b/includes/class-wc-product-accommodation-booking.php
@@ -322,7 +322,7 @@ class WC_Product_Accommodation_Booking extends WC_Product_Booking {
 	 *
 	 * @return array
 	 */
-	public function get_blocks_in_range( $start_date, $end_date, $intervals = array(), $resource_id = 0, $booked = array(), $get_past_times = false ) {
+	public function get_blocks_in_range( $start_date, $end_date, $intervals = array(), $resource_id = 0, $booked = array(), $get_past_times = false, $include_unavailable = false ) {
 
 		$blocks_in_range = $this->get_blocks_in_range_for_day( $start_date, $end_date, $resource_id, $booked );
 


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

With [this](https://github.com/woocommerce/woocommerce-bookings/pull/3310/files#diff-17e4ab0dcf6a3ea0b614d1a815470fc2a3a214d44680405803af201b1c40c6c2R1629) change in the bookings PR https://github.com/woocommerce/woocommerce-bookings/pull/3310, the following error started showing up:
```
( ! ) Warning: Declaration of WC_Product_Accommodation_Booking::get_blocks_in_range($start_date, $end_date, $intervals = Array, $resource_id = 0, $booked = Array, $get_past_times = false) should be compatible with WC_Product_Booking::get_blocks_in_range($start_date, $end_date, $intervals = Array, $resource_id = 0, $booked = Array, $get_past_times = false, $include_unavailable = false) in /Users/faisalalvi/LocalSites/wpne/app/public/wp-content/plugins/woocommerce-accommodation-bookings/includes/class-wc-product-accommodation-booking.php on line 325
```
And the bookable products calendar stopped loading at FE.
![image](https://user-images.githubusercontent.com/25176325/181483691-283f71fb-2455-47a8-a2a2-7a353224109c.png)
[image link](https://www.screencast.com/t/hqBTSyo3BOz)

This PR fixes this issue and the products are now loading fine.

**IMP: Both PRs should be released together, and people who use the accommodation plugin but only upgrades the bookings, not accommodation, may face this issue.**

### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce-bookings/issues/2398.

### How to test the changes in this Pull Request:

1. Import [booking-product-3853-2022-07-28.zip](https://github.com/woocommerce/woocommerce-accommodation-bookings/files/9208199/booking-product-3853-2022-07-28.zip)
2. Visit FE.
3. See the calendar should be loaded properly.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Bookings Calendar not loading properly.
