### PR TITLE
exclude node_modules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "license": "GPL-2.0+",
     "archive": {
         "exclude": [
+            "node_modules",
             "!/assets"
         ]
     },


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changes proposed in this Pull Request:

For composer V2, we need explicitly specify the exclude list to ignore the `node_modules` directory. 

Closes #268 

### How to test the changes in this Pull Request:

1. Confirm you are using composer V2 with `composer --version`
2. Run `npm run archive`
3. On the generated build file, confirm the `node_modules` directory not present

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry

> Fix - Build artifact includes node_modules.
