### PR TITLE
Minimum Version Bumps for WP, Woo, & PHP

### DIFF
--- a/includes/admin/class-wc-accommodation-booking-admin-panels.php
+++ b/includes/admin/class-wc-accommodation-booking-admin-panels.php
@@ -15,11 +15,7 @@ class WC_Accommodation_Booking_Admin_Panels {
 		add_filter( 'product_type_selector', array( $this, 'product_type_selector' ) );
 		add_filter( 'product_type_options', array( $this, 'product_type_options' ), 15 );
 
-		if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
-			add_action( 'woocommerce_product_write_panels', array( $this, 'panels' ) );
-		} else {
-			add_action( 'woocommerce_product_data_panels', array( $this, 'panels' ) );
-		}
+		add_action( 'woocommerce_product_data_panels', array( $this, 'panels' ) );
 
 		add_action( 'woocommerce_product_options_general_product_data', array( $this, 'general_product_data' ) );
 

--- a/includes/class-wc-accommodation-booking-order-manager.php
+++ b/includes/class-wc-accommodation-booking-order-manager.php
@@ -104,17 +104,10 @@ class WC_Accommodation_Booking_Order_Manager {
 			}
 
 			foreach ( $order->get_items() as $item ) {
-				if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
-					if ( 'line_item' === $item['type'] ) {
-						$product               = $order->get_product_from_item( $item );
-						$virtual_booking_order = $product && $product->is_virtual() && $product->is_type( 'accommodation-booking' );
-					}
-				} else {
-					if ( $item->is_type( 'line_item' ) ) {
-						$product               = $item->get_product();
-						$virtual_booking_order = $product && $product->is_virtual() && $product->is_type( 'accommodation-booking' );
-					}
-				}
+                if ( $item->is_type( 'line_item' ) ) {
+                    $product               = $item->get_product();
+                    $virtual_booking_order = $product && $product->is_virtual() && $product->is_type( 'accommodation-booking' );
+                }
 				if ( ! $virtual_booking_order ) {
 					break;
 				}

--- a/includes/class-wc-accommodation-booking-order-manager.php
+++ b/includes/class-wc-accommodation-booking-order-manager.php
@@ -104,10 +104,10 @@ class WC_Accommodation_Booking_Order_Manager {
 			}
 
 			foreach ( $order->get_items() as $item ) {
-                if ( $item->is_type( 'line_item' ) ) {
-                    $product               = $item->get_product();
-                    $virtual_booking_order = $product && $product->is_virtual() && $product->is_type( 'accommodation-booking' );
-                }
+				if ( $item->is_type( 'line_item' ) ) {
+					$product               = $item->get_product();
+					$virtual_booking_order = $product && $product->is_virtual() && $product->is_type( 'accommodation-booking' );
+				}
 				if ( ! $virtual_booking_order ) {
 					break;
 				}

--- a/includes/class-wc-accommodation-dependencies.php
+++ b/includes/class-wc-accommodation-dependencies.php
@@ -73,8 +73,8 @@ class WC_Accommodation_Dependencies {
 			throw new Exception( __( 'Accommodation Bookings requires Bookings version 1.9+.', 'woocommerce-accommodation-bookings' ) );
 		}
 
-		if ( ! version_compare( PHP_VERSION, '5.3', '>=' ) ) {
-			throw new Exception( __( 'Accommodation Bookings requires PHP version 5.3+.', 'woocommerce-accommodation-bookings' ) );
+		if ( ! version_compare( PHP_VERSION, '7.0', '>=' ) ) {
+			throw new Exception( __( 'Accommodation Bookings requires PHP version 7.0+.', 'woocommerce-accommodation-bookings' ) );
 		}
 	}
 }

--- a/includes/class-wc-accommodation-dependencies.php
+++ b/includes/class-wc-accommodation-dependencies.php
@@ -74,7 +74,7 @@ class WC_Accommodation_Dependencies {
 		}
 
 		if ( ! version_compare( PHP_VERSION, '7.0', '>=' ) ) {
-			throw new Exception( __( 'Accommodation Bookings requires PHP version 7.0+.', 'woocommerce-accommodation-bookings' ) );
+			throw new Exception( __( 'Accommodation Bookings requires PHP version 7.0 or above.', 'woocommerce-accommodation-bookings' ) );
 		}
 	}
 }

--- a/includes/class-wc-product-accommodation-booking.php
+++ b/includes/class-wc-product-accommodation-booking.php
@@ -165,11 +165,7 @@ class WC_Product_Accommodation_Booking extends WC_Product_Booking {
 		$display_price = $this->get_display_cost();
 		if ( ! $display_price ) {
 			$tax_display_mode = get_option( 'woocommerce_tax_display_shop' );
-			if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
-				$display_price = $tax_display_mode == 'incl' ? $this->get_price_including_tax( 1, $this->get_price() ) : $this->get_price_excluding_tax( 1, $this->get_price() );
-			} else {
-				$display_price = $tax_display_mode == 'incl' ? wc_get_price_including_tax( $this, array( 'qty' => 1, 'price' => $this->get_price() ) ) : wc_get_price_excluding_tax( $this, array( 'qty' => 1, 'price' => $this->get_price() ) );
-			}
+			$display_price = $tax_display_mode == 'incl' ? wc_get_price_including_tax( $this, array( 'qty' => 1, 'price' => $this->get_price() ) ) : wc_get_price_excluding_tax( $this, array( 'qty' => 1, 'price' => $this->get_price() ) );
 		}
 
 		if ( $display_price ) {

--- a/woocommerce-accommodation-bookings.php
+++ b/woocommerce-accommodation-bookings.php
@@ -9,8 +9,10 @@
  * Text Domain: woocommerce-accommodation-bookings
  * Domain Path: /languages
  * Tested up to: 6.0
+ * Requires at least: 5.6
  * WC tested up to: 6.7.0
  * WC requires at least: 6.0
+ * Requires PHP: 7.0
  *
  * Copyright: © 2022 WooCommerce
  * License: GNU General Public License v3.0

--- a/woocommerce-accommodation-bookings.php
+++ b/woocommerce-accommodation-bookings.php
@@ -10,7 +10,7 @@
  * Domain Path: /languages
  * Tested up to: 6.0
  * WC tested up to: 6.7.0
- * WC requires at least: 2.6
+ * WC requires at least: 6.0
  *
  * Copyright: © 2022 WooCommerce
  * License: GNU General Public License v3.0


### PR DESCRIPTION
### All Submissions:

* [ ] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR bumps WP, Woo, & PHP Minimums as below.

- WordPress to 5.6
- WooCommerce to 6.0
- PHP to 7.0

Closes #301.

### How to test the changes in this Pull Request:

This is just a minimum version bump, with no changes in any functionality so please check the overall plugin functionalities with minimum configuration.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Minimum Version Bumps: WP 5.6, Woo 6.0, & PHP 7.0
