### PR TITLE
Fix/308 Handle empty Rate with Range Cost Rule

### DIFF
--- a/includes/admin/views/html-accommodation-booking-rates-fields.php
+++ b/includes/admin/views/html-accommodation-booking-rates-fields.php
@@ -109,7 +109,7 @@
 		if ( ! empty( $rate['override_block'] ) ) {
 			echo $rate['override_block'];
 		} else if ( ! empty( $rate['modifier'] ) && isset( $rate['cost'] ) ) {
-			$base_cost = abs( get_post_meta( $post_id, '_wc_booking_base_cost', true ) );
+			$base_cost = abs( floatval( get_post_meta( $post_id, '_wc_booking_base_cost', true ) ) );
 
 			if ( 'plus' == $rate['modifier'] ) {
 				echo $base_cost + $rate['cost'];


### PR DESCRIPTION
### All Submissions:

* [ ] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR simply adds `floatval` wrapper around the product cost (ie `_wc_booking_base_cost`) to avoid fatal error when no cost is added but the cost rule is.

Closes #308.

### How to test the changes in this Pull Request:

1. Create a new accommodation product.
2. Go to the Rates tab
3. Without adding a Rate/Cost, add a Range: Range type > Range of certain nights | Starting any date | Ending any date | Cost: 100 > Click Publish.
4. Revisit the Rates or Availability tabs, there shouldn't be any errors as mentioned in the linked issue.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Fatal error when Rate is empty and Range Cost is added.