### PR TITLE
Compatibility/311 Declare compatibility with HPOS

### DIFF
--- a/includes/class-wc-accommodation-bookings-plugin.php
+++ b/includes/class-wc-accommodation-bookings-plugin.php
@@ -38,6 +38,20 @@ class WC_Accommodation_Bookings_Plugin {
 	public function __construct( $plugin_file, $version ) {
 		$this->plugin_file = $plugin_file;
 		$this->version     = $version;
+
+		// Declare compatibility with High-Performance Order Storage.
+		add_action( 'before_woocommerce_init', array( $this, 'declare_hpos_compatibility' ) );
+	}
+
+	/**
+	 * Declare compatibility with High-Performance Order Storage.
+	 *
+	 * @since x.x.x
+	 */
+	public function declare_hpos_compatibility() {
+		if ( class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) ) {
+			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', $this->plugin_file, true );
+		}
 	}
 
 	/**

--- a/includes/class-wc-accommodation-bookings-plugin.php
+++ b/includes/class-wc-accommodation-bookings-plugin.php
@@ -46,7 +46,7 @@ class WC_Accommodation_Bookings_Plugin {
 	/**
 	 * Declare compatibility with High-Performance Order Storage.
 	 *
-	 * @since x.x.x
+	 * @since 1.1.34
 	 */
 	public function declare_hpos_compatibility() {
 		if ( class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR declares compatibility with High-Performance Order Storage (HPOS).

Closes #311.

### How to test the changes in this Pull Request:

1. Make sure you have WooCommerce <= 6.9.4 installed
2. Check out this branch
3. Make sure no error showed up
4. Install [this](https://github.com/woocommerce/woocommerce/releases/tag/feature-custom-order-table) WooCommerce version or newer
5. Enable HPOS(COT) by following the steps from [here](https://github.com/woocommerce/woocommerce/wiki/High-Performance-Order-Storage-Upgrade-Recipe-Book#how-to-enable-hpos)
6. Go to WooCommerce > Status > Tools and run Create the custom orders tables.
7. Go to WooCommerce > Settings > Advanced > Custom data stores
8. Select Use the WooCommerce orders tables
9. Save
10. Make sure no error showed up
11. Buy a product to make sure no error is generated

### Other information:

* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add - Declare support for High-performance Order Storage ("HPOS").