### PR TITLE
Bump WordPress Tested up to 6.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Plugin Name ===
 Contributors:  woocommerce, automattic, woothemes, jshreve, akeda, bor0, jessepearson, laurendavissmith001, royho
 Tags: woocommerce, bookings, accommodations
-Requires at least: 4.1
+Requires at least: 5.6
 Tested up to: 6.1
 Stable tag: 1.1.36
 License: GNU General Public License v3.0

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:  woocommerce, automattic, woothemes, jshreve, akeda, bor0, jessepearson, laurendavissmith001, royho
 Tags: woocommerce, bookings, accommodations
 Requires at least: 4.1
-Tested up to: 5.8
+Tested up to: 6.1
 Stable tag: 1.1.36
 License: GNU General Public License v3.0
 License URI: http://www.gnu.org/licenses/gpl-3.0.html

--- a/woocommerce-accommodation-bookings.php
+++ b/woocommerce-accommodation-bookings.php
@@ -9,7 +9,7 @@
  * Text Domain: woocommerce-accommodation-bookings
  * Domain Path: /languages
  * Tested up to: 6.0
- * Requires at least: 5.6
+ * Requires at least: 6.1
  * WC tested up to: 6.7.0
  * WC requires at least: 6.0
  * Requires PHP: 7.0

--- a/woocommerce-accommodation-bookings.php
+++ b/woocommerce-accommodation-bookings.php
@@ -8,8 +8,8 @@
  * Author URI: https://woocommerce.com
  * Text Domain: woocommerce-accommodation-bookings
  * Domain Path: /languages
- * Tested up to: 6.0
- * Requires at least: 6.1
+ * Tested up to: 6.1
+ * Requires at least: 5.6
  * WC tested up to: 6.7.0
  * WC requires at least: 6.0
  * Requires PHP: 7.0


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Bumping the WordPress minimum (Requires at least) to 6.1

Closes #319.

### How to test the changes in this Pull Request:

Pretty straight forward testing, just check the plugin in WP v6.1.

### Other information:

* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Bump minimum required WordPress version from 4.1 to 5.6.
> Tweak - Bump WordPress tested up to version from 6.0 to 6.1.
