### PR TITLE
Enhancement/323 Setting page moved from "Bookings → Settings" to "WooCommerce → Settings → Bookings"

### DIFF
--- a/includes/admin/class-wc-accommodation-booking-admin-product-settings.php
+++ b/includes/admin/class-wc-accommodation-booking-admin-product-settings.php
@@ -60,7 +60,7 @@ class WC_Accommodation_Booking_Admin_Product_Settings extends WC_Settings_API {
 	 */
 	public function update_bookings_sections( $sections ) {
 		// If not array, return as it is.
-		if( ! is_array( $sections ) ) {
+		if ( ! is_array( $sections ) ) {
 			return $sections;
 		}
 

--- a/includes/admin/class-wc-accommodation-booking-admin-product-settings.php
+++ b/includes/admin/class-wc-accommodation-booking-admin-product-settings.php
@@ -103,7 +103,6 @@ class WC_Accommodation_Booking_Admin_Product_Settings extends WC_Settings_API {
 	public function add_accommodation_settings( $tabs_metadata ) {
 		$tabs_metadata['accommodation'] = array(
 			'name'          => __( 'Accommodation', 'woocommerce-bookings' ),
-			'href'          => admin_url( 'edit.php?post_type=wc_booking&page=wc_bookings_settings&tab=accommodation' ),
 			'capability'    => 'manage_options',
 			'generate_html' => 'WC_Accommodation_Booking_Admin_Product_Settings::generate_form_html',
 		);

--- a/includes/admin/class-wc-accommodation-booking-admin-product-settings.php
+++ b/includes/admin/class-wc-accommodation-booking-admin-product-settings.php
@@ -46,6 +46,27 @@ class WC_Accommodation_Booking_Admin_Product_Settings extends WC_Settings_API {
 
 		add_action( 'admin_init', array( $this, 'maybe_save_settings' ) );
 		add_filter( 'woocommerce_bookings_settings_page', array( $this, 'add_accommodation_settings' ) );
+		add_filter( 'woocommerce_get_sections_bookings', array( $this, 'update_bookings_sections' ) );
+	}
+
+	/**
+	 * Update the settings sections.
+	 *
+	 * @since x.x.x
+	 * 
+	 * @param array Existing sections.
+	 *
+	 * @return array Updated sections.
+	 */
+	public function update_bookings_sections( $sections ) {
+		// If not array, return as it is.
+		if( ! is_array( $sections ) ) {
+			return $sections;
+		}
+
+		$sections['accommodation'] = __( 'Accommodation', 'woocommerce-accommodation-bookings' );
+
+		return $sections;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

**NOTE:** This PR is dependent on https://github.com/woocommerce/woocommerce-bookings/pull/3462, please release both of these together.

* Moving the setting page under the WooCommerce → Settings → Bookings.
* Adding a new section there called, "Accommodation".

![image](https://user-images.githubusercontent.com/25176325/213443457-311dfd2d-ac10-4049-bded-432623b9f2cb.png)

Closes #323.

### How to test the changes in this Pull Request:

* Visit WooCommerce → Settings → Bookings and confirm the "Accommodation" setting page is moved and it is working as expected.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Change - The setting page is moved from "Bookings → Settings" to "WooCommerce → Settings → Bookings"
