### PR TITLE
Tweak/326 Bump WooCommerce "Tested up to" to 7.3

### DIFF
--- a/woocommerce-accommodation-bookings.php
+++ b/woocommerce-accommodation-bookings.php
@@ -10,7 +10,7 @@
  * Domain Path: /languages
  * Tested up to: 6.0
  * Requires at least: 5.6
- * WC tested up to: 6.7.0
+ * WC tested up to: 7.3
  * WC requires at least: 6.0
  * Requires PHP: 7.0
  *


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

### **Description:**

This PR bumps the WooCommerce tested up to version from `v6.7.0` to → `v7.3`.

### Tested cases:

- ✅ Accommodation product checkout without issues.
- ✅ Accommodation product with resources.
- ✅ Accommodation product with persons.
- ✅ Updating the order status also updates the bookings’ status.
- ✅ Accommodation product without resources.

Closes #326.

### How to test the changes in this Pull Request:

1. Except for the version bump, nothing has changed; simply verify the plugin's functioning.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Bump WooCommerce "tested up to" from 6.7 to 7.3.
