### PR TITLE
Enhancement/317-169 Ability to set product-level check-in/out times

### DIFF
--- a/includes/class-wc-accommodation-booking-cart-manager.php
+++ b/includes/class-wc-accommodation-booking-cart-manager.php
@@ -33,8 +33,8 @@ class WC_Accommodation_Booking_Cart_Manager {
 	 */
 	public function get_item_data( $other_data, $cart_item ) {
 		if ( 'accommodation-booking' === $cart_item['data']->get_type() && ! empty( $other_data ) ) {
-			$check_in  = WC_Product_Accommodation_Booking::get_check_times( 'in' );
-			$check_out = WC_Product_Accommodation_Booking::get_check_times( 'out' );
+			$check_in  = WC_Product_Accommodation_Booking::get_check_times( 'in', $cart_item['product_id'] );
+			$check_out = WC_Product_Accommodation_Booking::get_check_times( 'out', $cart_item['product_id'] );
 			$end_date  = date_i18n( get_option( 'date_format'), $cart_item['booking']['_end_date'] );
 
 			if ( ! empty( $check_in ) ) {

--- a/includes/class-wc-accommodation-booking-date-picker.php
+++ b/includes/class-wc-accommodation-booking-date-picker.php
@@ -29,8 +29,8 @@ class WC_Accommodation_Booking_Date_Picker {
 	 * @return mixed
 	 */
 	public function add_accommodation_posted_data( $data, $product, $total_duration ) {
-		$check_in  = WC_Product_Accommodation_Booking::get_check_times( 'in' );
-		$check_out = WC_Product_Accommodation_Booking::get_check_times( 'out' );
+		$check_in  = WC_Product_Accommodation_Booking::get_check_times( 'in', $product->get_id() );
+		$check_out = WC_Product_Accommodation_Booking::get_check_times( 'out', $product->get_id() );
 
 		if ( 'night' === $product->get_duration_unit() ) {
 			$data['_start_date'] = strtotime( "{$data['_year']}-{$data['_month']}-{$data['_day']} $check_in" );
@@ -106,7 +106,7 @@ class WC_Accommodation_Booking_Date_Picker {
 						continue;
 					}
 
-					$check_in_time = $product->get_check_times( 'in' );
+					$check_in_time = $product->get_check_times( 'in', $product->get_id() );
 					if ( 'in' === $which ) {
 						$check_time = strtotime( '-1 day ' . $check_in_time , $time );
 					} else {

--- a/includes/class-wc-accommodation-booking-order-manager.php
+++ b/includes/class-wc-accommodation-booking-order-manager.php
@@ -33,8 +33,8 @@ class WC_Accommodation_Booking_Order_Manager {
 			return;
 		}
 
-		$check_in  = WC_Product_Accommodation_Booking::get_check_times( 'in' );
-		$check_out = WC_Product_Accommodation_Booking::get_check_times( 'out' );
+		$check_in  = WC_Product_Accommodation_Booking::get_check_times( 'in', $item['product_id'] );
+		$check_out = WC_Product_Accommodation_Booking::get_check_times( 'out', $item['product_id'] );
 		?>
 		<p>
 		<strong><?php esc_html_e( 'Check-in', 'woocommerce-accommodation-bookings' ); ?> </strong>

--- a/includes/class-wc-accommodation-booking-product-tabs.php
+++ b/includes/class-wc-accommodation-booking-product-tabs.php
@@ -11,6 +11,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WC_Accommodation_Booking_Product_Tabs {
 
 	/**
+	 * Product ID.
+	 */
+	public $product_id = 0;
+
+	/**
 	 * Hook into WooCommerce..
 	 */
 	public function __construct() {
@@ -22,8 +27,8 @@ class WC_Accommodation_Booking_Product_Tabs {
 	 * @return boolean
 	 */
 	public function are_time_fields_filled_out() {
-		$check_in  = WC_Product_Accommodation_Booking::get_check_times( 'in' );
-		$check_out = WC_Product_Accommodation_Booking::get_check_times( 'out' );
+		$check_in  = WC_Product_Accommodation_Booking::get_check_times( 'in', $this->product_id );
+		$check_out = WC_Product_Accommodation_Booking::get_check_times( 'out', $this->product_id );
 
 		if ( empty( $check_in ) ) {
 			return false;
@@ -56,6 +61,9 @@ class WC_Accommodation_Booking_Product_Tabs {
 			return $tabs;
 		}
 
+		// Set the product ID.
+		$this->product_id = $post->ID;
+
 		if ( ! $this->are_time_fields_filled_out() ) {
 			return $tabs;
 		}
@@ -77,8 +85,8 @@ class WC_Accommodation_Booking_Product_Tabs {
 		if ( ! $this->are_time_fields_filled_out() ) {
 			return;
 		}
-		$check_in  = WC_Product_Accommodation_Booking::get_check_times( 'in' );
-		$check_out = WC_Product_Accommodation_Booking::get_check_times( 'out' );
+		$check_in  = WC_Product_Accommodation_Booking::get_check_times( 'in', $this->product_id );
+		$check_out = WC_Product_Accommodation_Booking::get_check_times( 'out', $this->product_id );
 		?>
 		<h2><?php echo esc_html( apply_filters( 'woocommerce_accommodation_booking_time_tab_heading', __( 'Arriving/leaving', 'woocommerce-accommodation-bookings' ) ) ); ?></h2>
 		<ul>

--- a/includes/class-wc-accommodation-booking.php
+++ b/includes/class-wc-accommodation-booking.php
@@ -109,12 +109,10 @@ class WC_Accommodation_Booking {
 			return $date;
 		}
 
-		$check_in  = WC_Product_Accommodation_Booking::get_check_times( 'in', $product->get_id() );
-
 		$date_format = apply_filters( 'woocommerce_bookings_date_format', wc_date_format() );
 		$time_format = apply_filters( 'woocommerce_bookings_time_format', ', ' . wc_time_format() );
 
-		return date_i18n( $date_format, $booking->start ) . date_i18n( $time_format, strtotime( "Today " . $check_in ) );
+		return date_i18n( $date_format, $booking->start ) . date_i18n( $time_format, $booking->start );
 	}
 
 	public function add_checkout_time_to_booking_end_time( $date, $booking ) {
@@ -123,11 +121,10 @@ class WC_Accommodation_Booking {
 			return $date;
 		}
 
-		$check_out = WC_Product_Accommodation_Booking::get_check_times( 'out', $product->get_id() );
 		$date_format = apply_filters( 'woocommerce_bookings_date_format', wc_date_format() );
 		$time_format = apply_filters( 'woocommerce_bookings_time_format', ', ' . wc_time_format() );
 
-		return date_i18n( $date_format, $booking->end ) . date_i18n( $time_format, strtotime( "Today " . $check_out ) );
+		return date_i18n( $date_format, $booking->end ) . date_i18n( $time_format, $booking->end );
 	}
 
 	/**

--- a/includes/class-wc-accommodation-booking.php
+++ b/includes/class-wc-accommodation-booking.php
@@ -109,7 +109,7 @@ class WC_Accommodation_Booking {
 			return $date;
 		}
 
-		$check_in  = WC_Product_Accommodation_Booking::get_check_times( 'in' );
+		$check_in  = WC_Product_Accommodation_Booking::get_check_times( 'in', $product->get_id() );
 
 		$date_format = apply_filters( 'woocommerce_bookings_date_format', wc_date_format() );
 		$time_format = apply_filters( 'woocommerce_bookings_time_format', ', ' . wc_time_format() );
@@ -123,7 +123,7 @@ class WC_Accommodation_Booking {
 			return $date;
 		}
 
-		$check_out = WC_Product_Accommodation_Booking::get_check_times( 'out' );
+		$check_out = WC_Product_Accommodation_Booking::get_check_times( 'out', $product->get_id() );
 		$date_format = apply_filters( 'woocommerce_bookings_date_format', wc_date_format() );
 		$time_format = apply_filters( 'woocommerce_bookings_time_format', ', ' . wc_time_format() );
 
@@ -181,8 +181,8 @@ class WC_Accommodation_Booking {
 			return;
 		}
 
-		$check_in  = WC_Product_Accommodation_Booking::get_check_times( 'in' );
-		$check_out = WC_Product_Accommodation_Booking::get_check_times( 'out' );
+		$check_in  = WC_Product_Accommodation_Booking::get_check_times( 'in', $product_id );
+		$check_out = WC_Product_Accommodation_Booking::get_check_times( 'out', $product_id );
 
 		$start = get_post_meta( $booking_id, '_booking_start', true );
 		$end   = get_post_meta( $booking_id, '_booking_end', true );

--- a/includes/class-wc-product-accommodation-booking.php
+++ b/includes/class-wc-product-accommodation-booking.php
@@ -328,20 +328,34 @@ class WC_Product_Accommodation_Booking extends WC_Product_Booking {
 	/**
 	 * Get checkin and checkout times.
 	 *
-	 * @param string $type
+	 * @param string $type       The type, check_in or check_out.
+	 * @param int    $product_id The product ID.
 	 *
-	 * @return string Time, either from options or default
+	 * @return string The time, either from options or default or from the filtered value.
 	 */
-	public static function get_check_times( $type ) {
-		$option = get_option( 'woocommerce_accommodation_bookings_times_settings' );
+	public static function get_check_times( $type, $product_id = 0 ) {
+		$option     = get_option( 'woocommerce_accommodation_bookings_times_settings' );
+		$check_time = '';
+
 		switch ( $type ) {
 			case 'in':
-				return isset( $option['check_in'] ) ? $option['check_in'] : '14:00';
+				$check_time = isset( $option['check_in'] ) ? $option['check_in'] : '14:00';
 			case 'out':
-				return isset( $option['check_out'] ) ? $option['check_out'] : '14:00';
+				$check_time = isset( $option['check_out'] ) ? $option['check_out'] : '14:00';
 		}
 
-		return '';
+		/**
+		 * Filter the check-in/out times for a specific product.
+		 *
+		 * @hook woocommerce_accommodation_booking_get_check_times
+		 *
+		 * @param {string} $check_time The check-in/out time stored in the database.
+		 * @param {string} $type       The type, check_in or check_out.
+		 * @param {int}    $product_id The product ID.
+		 *
+		 * @return {string} The filtered/original time.
+		 */
+		return apply_filters( 'woocommerce_accommodation_booking_get_check_times', $check_time, $type, $product_id );
 	}
 
 	/**

--- a/includes/class-wc-product-accommodation-booking.php
+++ b/includes/class-wc-product-accommodation-booking.php
@@ -350,13 +350,11 @@ class WC_Product_Accommodation_Booking extends WC_Product_Booking {
 		/**
 		 * Filter the check-in/out times for a specific product.
 		 *
-		 * @hook woocommerce_accommodation_booking_get_check_times
-		 *
 		 * @param string $check_time The check-in/out time stored in the database.
 		 * @param string $type       The type, check_in or check_out.
 		 * @param int    $product_id The product ID.
 		 *
-		 * @return {string} The filtered/original time.
+		 * @return string The filtered/original time.
 		 */
 		return apply_filters( 'woocommerce_accommodation_booking_get_check_times', $check_time, $type, (int) $product_id );
 	}

--- a/includes/class-wc-product-accommodation-booking.php
+++ b/includes/class-wc-product-accommodation-booking.php
@@ -352,9 +352,9 @@ class WC_Product_Accommodation_Booking extends WC_Product_Booking {
 		 *
 		 * @hook woocommerce_accommodation_booking_get_check_times
 		 *
-		 * @param {string} $check_time The check-in/out time stored in the database.
-		 * @param {string} $type       The type, check_in or check_out.
-		 * @param {int}    $product_id The product ID.
+		 * @param string $check_time The check-in/out time stored in the database.
+		 * @param string $type       The type, check_in or check_out.
+		 * @param int    $product_id The product ID.
 		 *
 		 * @return {string} The filtered/original time.
 		 */

--- a/includes/class-wc-product-accommodation-booking.php
+++ b/includes/class-wc-product-accommodation-booking.php
@@ -340,10 +340,10 @@ class WC_Product_Accommodation_Booking extends WC_Product_Booking {
 
 		switch ( $type ) {
 			case 'in':
-				$check_time = isset( $option['check_in'] ) ? $option['check_in'] : '14:00';
+				$check_time = $option['check_in'] ?? '14:00';
 				break;
 			case 'out':
-				$check_time = isset( $option['check_out'] ) ? $option['check_out'] : '14:00';
+				$check_time = $option['check_out'] ?? '14:00';
 				break;
 		}
 

--- a/includes/class-wc-product-accommodation-booking.php
+++ b/includes/class-wc-product-accommodation-booking.php
@@ -358,7 +358,7 @@ class WC_Product_Accommodation_Booking extends WC_Product_Booking {
 		 *
 		 * @return {string} The filtered/original time.
 		 */
-		return apply_filters( 'woocommerce_accommodation_booking_get_check_times', $check_time, $type, $product_id );
+		return apply_filters( 'woocommerce_accommodation_booking_get_check_times', $check_time, $type, (int) $product_id );
 	}
 
 	/**

--- a/includes/class-wc-product-accommodation-booking.php
+++ b/includes/class-wc-product-accommodation-booking.php
@@ -341,8 +341,10 @@ class WC_Product_Accommodation_Booking extends WC_Product_Booking {
 		switch ( $type ) {
 			case 'in':
 				$check_time = isset( $option['check_in'] ) ? $option['check_in'] : '14:00';
+				break;
 			case 'out':
 				$check_time = isset( $option['check_out'] ) ? $option['check_out'] : '14:00';
+				break;
 		}
 
 		/**

--- a/includes/class-wc-product-accommodation-booking.php
+++ b/includes/class-wc-product-accommodation-booking.php
@@ -195,15 +195,16 @@ class WC_Product_Accommodation_Booking extends WC_Product_Booking {
 	public function get_time_slots( $blocks, $resource_id = 0, $from = 0, $to = 0, $include_sold_out = false ) {
 		$bookable_product = $this;
 
-		$transient_name               = 'book_ts_' . md5( http_build_query( array( $bookable_product->get_id(), $resource_id, $from, $to ) ) );
+		$product_id                   = $bookable_product->get_id();
+		$transient_name               = 'book_ts_' . md5( http_build_query( array( $product_id, $resource_id, $from, $to ) ) );
 		$available_slots              = get_transient( $transient_name );
 		$booking_slots_transient_keys = array_filter( (array) get_transient( 'booking_slots_transient_keys' ) );
 
-		if ( ! isset( $booking_slots_transient_keys[ $bookable_product->get_id() ] ) ) {
-			$booking_slots_transient_keys[ $bookable_product->get_id() ] = array();
+		if ( ! isset( $booking_slots_transient_keys[ $product_id ] ) ) {
+			$booking_slots_transient_keys[ $product_id ] = array();
 		}
 
-		$booking_slots_transient_keys[ $bookable_product->get_id() ][] = $transient_name;
+		$booking_slots_transient_keys[ $product_id ][] = $transient_name;
 
 		// Give array of keys a long ttl because if it expires we won't be able to flush the keys when needed.
 		// We can't use 0 to never expire because then WordPress will autoload the option on every page.
@@ -229,8 +230,8 @@ class WC_Product_Accommodation_Booking extends WC_Product_Booking {
 			$has_resources    = $bookable_product->has_resources();
 
 			foreach ( $blocks as $block ) {
-				$check_in  = WC_Product_Accommodation_Booking::get_check_times( 'in' );
-				$check_out = WC_Product_Accommodation_Booking::get_check_times( 'out' );
+				$check_in  = WC_Product_Accommodation_Booking::get_check_times( 'in', $product_id );
+				$check_out = WC_Product_Accommodation_Booking::get_check_times( 'out', $product_id );
 				// Blocks for accommodation products are initially calculated as days but the actuall time blocks are shifted by check in and checkout times.
 				$block_start_time = strtotime( "{$check_in}", $block );
 				$block_end_time =  strtotime( "{$check_out}", strtotime( "+1 days", $block ) );


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR introduces a new filter `woocommerce_accommodation_booking_get_check_times` that allows users to filter the check-in/out times per product.

Closes #169,
Closes #317.

### How to test the changes in this Pull Request:
1. Visit WP Admin → Bookings → Settings → Accommodation (tab).
2. Change the check-in time to 9 AM and check-out to 9 AM. (this is just an example)
3. Open any accommodation product and note that when you add it in the cart, it displays the 9 AM as check-in and check-out times.
4. Also, if you are in a storefront theme, you would see “Arriving/leaving” tab on the product page with the same times.
5. Now add the following code in your theme's `functions.php`:
```
add_filter( 'woocommerce_accommodation_booking_get_check_times', function( $check_time, $type, $product_id ) {
	if ( 123 === (int) $product_id ) {
		$check_time = 'in' === $type ? '13:00' : $check_time;
		$check_time = 'out' === $type ? '14:00' : $check_time;
	}

	return $check_time;
}, 10, 3 );
```
6. Make sure to change the product ID in above code from 123 to your accommodation product's ID.
7. Now check again, the check-in time should be 1 PM and check-out time should be 2 PM (because we’ve filtered it using the above code).
8. Try changing the timings in the code and confirm it works as expected.
9. Also, test various places if the filtered timings display correctly. For example, on cart page, check out page, order success page, bookings edit page, etc.

### Other information:

* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Added a new filter, `woocommerce_accommodation_booking_get_check_times`, to change the check-in/out timings per product.
