### PR TITLE
Bump WordPress Tested up to version to 6.3

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -14,7 +14,7 @@
 	<exclude-pattern>*/dist/*</exclude-pattern>
 	<exclude-pattern>*/languages/*</exclude-pattern>
 
-	<config name="minimum_supported_wp_version" value="5.6"/>
+	<config name="minimum_supported_wp_version" value="6.1"/>
 
 	<!-- ensure we are using language features according to supported PHP versions -->
 	<config name="testVersion" value="7.0-"/>

--- a/woocommerce-accommodation-bookings.php
+++ b/woocommerce-accommodation-bookings.php
@@ -8,7 +8,7 @@
  * Author URI: https://woocommerce.com
  * Text Domain: woocommerce-accommodation-bookings
  * Domain Path: /languages
- * Tested up to: 6.2
+ * Tested up to: 6.3
  * Requires at least: 6.1
  * WC tested up to: 7.8
  * WC requires at least: 7.2


### PR DESCRIPTION
### All Submissions:

* [ ] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #357.

### How to test the changes in this Pull Request:

Test the plugin features with WP 6.3 RC3. Follow the checklist mentioned in https://github.com/woocommerce/woocommerce-accommodation-bookings/issues/357#issue-1833136270

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Bump WordPress "tested up to" version from 6.2 to 6.3.