### PR TITLE
Bump WooCommerce "tested up to" version 8.0

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set PHP version
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.0
+          php-version: 7.3
           tools: composer:v2
           coverage: none
       - name: Install dependencies

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set PHP version
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.0
+          php-version: 7.3
           tools: composer:v2
           coverage: none
       - name: Install dependencies

--- a/includes/class-wc-accommodation-dependencies.php
+++ b/includes/class-wc-accommodation-dependencies.php
@@ -73,8 +73,8 @@ class WC_Accommodation_Dependencies {
 			throw new Exception( __( 'Accommodation Bookings requires Bookings version 1.9+.', 'woocommerce-accommodation-bookings' ) );
 		}
 
-		if ( ! version_compare( PHP_VERSION, '7.0', '>=' ) ) {
-			throw new Exception( __( 'Accommodation Bookings requires PHP version 7.0 or above.', 'woocommerce-accommodation-bookings' ) );
+		if ( ! version_compare( PHP_VERSION, '7.3', '>=' ) ) {
+			throw new Exception( __( 'Accommodation Bookings requires PHP version 7.3 or above.', 'woocommerce-accommodation-bookings' ) );
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "archive": "composer archive --file=$npm_package_name --format=zip",
     "postarchive": "rm -rf $npm_package_name && unzip $npm_package_name.zip -d $npm_package_name && rm $npm_package_name.zip && zip -r $npm_package_name.zip $npm_package_name && rm -rf $npm_package_name",
     "makepot": "wp i18n make-pot . --exclude=tests,assets",
-    "phpcompat": "./vendor/bin/phpcs *.php includes -p --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion 7.0-",
+    "phpcompat": "./vendor/bin/phpcs *.php includes -p --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion 7.3-",
     "lint:js": "wp-scripts lint-js --ext=js",
     "lint:js-fix": "wp-scripts lint-js --ext=js --fix",
     "lint:style": "wp-scripts lint-style",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -17,7 +17,7 @@
 	<config name="minimum_supported_wp_version" value="5.6"/>
 
 	<!-- ensure we are using language features according to supported PHP versions -->
-	<config name="testVersion" value="7.0-"/>
+	<config name="testVersion" value="7.3-"/>
 	<rule ref="PHPCompatibilityWP" />
 	<rule ref="WordPress.WP.I18n">
 		<properties>

--- a/woocommerce-accommodation-bookings.php
+++ b/woocommerce-accommodation-bookings.php
@@ -10,9 +10,9 @@
  * Domain Path: /languages
  * Tested up to: 6.2
  * Requires at least: 6.1
- * WC tested up to: 7.8
- * WC requires at least: 7.2
- * Requires PHP: 7.0
+ * WC tested up to: 8.0
+ * WC requires at least: 7.8
+ * Requires PHP: 7.3
  *
  * Copyright: © 2023 WooCommerce
  * License: GNU General Public License v3.0


### PR DESCRIPTION
### All Submissions:

* [ ] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Smoke test with WC 8.0.

Closes #358.

### How to test the changes in this Pull Request:

Test the plugin features with WC 8.0. Follow the checklist mentioned in https://github.com/woocommerce/woocommerce-accommodation-bookings/issues/358#issue-1836261630.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Bump WooCommerce "tested up to" version from 7.8 to 8.0.
> Dev - Bump WooCommerce minimum supported version from 7.2 to 7.8.
> Dev - Bump PHP minimum supported version from 7.0 to 7.3.
