### PR TITLE
Assets: Hard code the paths to the asset data files

### DIFF
--- a/includes/class-wc-accommodation-bookings-plugin.php
+++ b/includes/class-wc-accommodation-bookings-plugin.php
@@ -213,11 +213,12 @@ class WC_Accommodation_Bookings_Plugin {
 	 * Frontend booking form scripts
 	 */
 	public function frontend_assets() {
-		$booking_style_asset_data  = $this->get_asset_data( 'frontend', 'css' );
-		$booking_script_asset_data = $this->get_asset_data( 'booking-form', 'js/frontend' );
+		$dist_path   = dirname( WC_ACCOMMODATION_BOOKINGS_MAIN_FILE ) . '/dist';
+		$style_data  = include $dist_path . '/css/frontend.asset.php';
+		$script_data = include $dist_path . '/js/frontend/booking-form.asset.php';
 
-		$booking_script_dependencies = array_merge(
-			$booking_script_asset_data['dependencies'],
+		$script_dependencies = array_merge(
+			$script_data['dependencies'],
 			array( 'wc-bookings-booking-form' )
 		);
 
@@ -225,14 +226,14 @@ class WC_Accommodation_Bookings_Plugin {
 			'wc-accommodation-bookings-styles',
 			WC_ACCOMMODATION_BOOKINGS_PLUGIN_URL . '/dist/css/frontend.css',
 			null,
-			$booking_style_asset_data['version']
+			$style_data['version']
 		);
 
 		wp_enqueue_script(
 			'wc-accommodation-bookings-form',
 			WC_ACCOMMODATION_BOOKINGS_PLUGIN_URL . '/dist/js/frontend/booking-form.js',
-			$booking_script_dependencies,
-			$booking_script_asset_data['version'],
+			$script_dependencies,
+			$script_data['version'],
 			true
 		);
 
@@ -311,19 +312,5 @@ class WC_Accommodation_Bookings_Plugin {
 
 		// Update version.
 		update_option( 'wc_accommodation_bookings_version', $this->version );
-	}
-
-	/**
-	 * Should return data from the asset file.
-	 *
-	 * @param string $script_file_name Script file name.
-	 * @param string $location Script file location.
-	 *
-	 * @return array
-	 */
-	private function get_asset_data( $script_file_name, $location ): array {
-		$asset_path = dirname( WC_ACCOMMODATION_BOOKINGS_MAIN_FILE ) . "/dist/$location/$script_file_name.asset.php";
-
-		return require $asset_path;
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This avoids the QIT violation `audit.php.lang.security.file.inclusion-arg`:

> Argument of a function used in an include/require, could lead to File Inclusion

This error could also be avoided by adding a `nosemgrep` exception, but in this case a refactor seemed better:

* The `get_asset_data` method containing the violation was only used in one other method, and only for loading two files, so the abstraction wasn't really necessary.
* This keeps the code less vulnerable than if in the future the `get_asset_data` was made public and/or used to load files based on untrusted user input.
* It's always better not to add linting exceptions when possible.

### How to test the changes in this Pull Request:

Testing this just involves making sure that the two asset files still enqueue successfully and have the correct props set. One quick and easy way to do this is via wp-cli:

1. Check out and build this branch, and then activate the plugin. The WooCommerce Bookings plugin may also need to be activated, since this plugin depends on it.
2. Open a wp-cli shell, `wp shell`, and run the following commands:

```
// This should not throw any errors related to requiring a file
wp_enqueue_scripts()

global $wp_styles, $wp_scripts

$wp_styles->registered['wc-accommodation-bookings-styles']
$wp_scripts->registered['wc-accommodation-bookings-form']
```

The `$wp_styles` command should output something like this:

```
=> object(_WP_Dependency)#4236 (8) {
  ["handle"]=>
  string(32) "wc-accommodation-bookings-styles"
  ["src"]=>
  string(97) "http://localhost:8888/wp-content/plugins/woocommerce-accommodation-bookings/dist/css/frontend.css"
  ["deps"]=>
  array(0) {
  }
  ["ver"]=>
  string(20) "83a366d1efedd293c794"
  ["args"]=>
  string(3) "all"
  ["extra"]=>
  array(0) {
  }
  ["textdomain"]=>
  NULL
  ["translations_path"]=>
  NULL
}
```

The `$wp_scripts` command should output something like this:

```
=> object(_WP_Dependency)#6151 (8) {
  ["handle"]=>
  string(30) "wc-accommodation-bookings-form"
  ["src"]=>
  string(108) "http://localhost:8888/wp-content/plugins/woocommerce-accommodation-bookings/dist/js/frontend/booking-form.js"
  ["deps"]=>
  array(2) {
    [0]=>
    string(7) "wp-i18n"
    [1]=>
    string(24) "wc-bookings-booking-form"
  }
  ["ver"]=>
  string(20) "7f8543234731b03e0414"
  ["args"]=>
  NULL
  ["extra"]=>
  array(1) {
    ["group"]=>
    int(1)
  }
  ["textdomain"]=>
  string(34) "woocommerce-accommodation-bookings"
  ["translations_path"]=>
  string(78) "/var/www/html/wp-content/plugins/woocommerce-accommodation-bookings//languages"
}
```

### Changelog entry

> Dev - Hard code the paths to the asset data files.

Is a changelog necessary in this case? This does not change any functionality, only fixes a QIT violation.
