### PR TITLE
Fix/363 - Fatal Error when WooCommerce is disabled

### DIFF
--- a/includes/class-wc-accommodation-bookings-plugin.php
+++ b/includes/class-wc-accommodation-bookings-plugin.php
@@ -192,7 +192,7 @@ class WC_Accommodation_Bookings_Plugin {
 	 *
 	 * @since x.x.x
 	 */
-	public function woocommerce_accommodation_bookings_missing_wc_notice() {
+	public function missing_wc_notice() {
 		/* translators: %s WC download URL link. */
 		echo '<div class="error"><p><strong>' . sprintf( esc_html__( 'Accommodation Bookings requires WooCommerce to be installed and active. You can download %s here.', 'woocommerce-accommodation-bookings' ), '<a href="https://woocommerce.com/" target="_blank">WooCommerce</a>' ) . '</strong></p></div>';
 	}
@@ -218,7 +218,7 @@ class WC_Accommodation_Bookings_Plugin {
 
 		// Return if WooCommerce class not found.
 		if ( ! class_exists( 'WooCommerce' ) ) {
-			add_action( 'admin_notices', array( $this, 'woocommerce_accommodation_bookings_missing_wc_notice' ) );
+			add_action( 'admin_notices', array( $this, 'missing_wc_notice' ) );
 			return;
 		}
 

--- a/includes/class-wc-accommodation-bookings-plugin.php
+++ b/includes/class-wc-accommodation-bookings-plugin.php
@@ -188,6 +188,16 @@ class WC_Accommodation_Bookings_Plugin {
 	}
 
 	/**
+	 * WooCommerce fallback notice.
+	 *
+	 * @since x.x.x
+	 */
+	public function woocommerce_accommodation_bookings_missing_wc_notice() {
+		/* translators: %s WC download URL link. */
+		echo '<div class="error"><p><strong>' . sprintf( esc_html__( 'Accommodation Bookings requires WooCommerce to be installed and active. You can download %s here.', 'woocommerce-accommodation-bookings' ), '<a href="https://woocommerce.com/" target="_blank">WooCommerce</a>' ) . '</strong></p></div>';
+	}
+
+	/**
 	 * Load Classes
 	 */
 	public function includes() {
@@ -205,6 +215,13 @@ class WC_Accommodation_Bookings_Plugin {
 	 * Include admin
 	 */
 	public function admin_includes() {
+
+		// Return if WooCommerce class not found.
+		if ( ! class_exists( 'WooCommerce' ) ) {
+			add_action( 'admin_notices', array( $this, 'woocommerce_accommodation_bookings_missing_wc_notice' ) );
+			return;
+		}
+
 		include WC_ACCOMMODATION_BOOKINGS_INCLUDES_PATH . 'admin/class-wc-accommodation-booking-admin-panels.php';
 		include WC_ACCOMMODATION_BOOKINGS_INCLUDES_PATH . 'admin/class-wc-accommodation-booking-admin-product-settings.php';
 	}

--- a/includes/class-wc-accommodation-bookings-plugin.php
+++ b/includes/class-wc-accommodation-bookings-plugin.php
@@ -215,7 +215,6 @@ class WC_Accommodation_Bookings_Plugin {
 	 * Include admin
 	 */
 	public function admin_includes() {
-
 		// Return if WooCommerce class not found.
 		if ( ! class_exists( 'WooCommerce' ) ) {
 			add_action( 'admin_notices', array( $this, 'missing_wc_notice' ) );

--- a/includes/class-wc-accommodation-bookings-plugin.php
+++ b/includes/class-wc-accommodation-bookings-plugin.php
@@ -190,7 +190,7 @@ class WC_Accommodation_Bookings_Plugin {
 	/**
 	 * WooCommerce fallback notice.
 	 *
-	 * @since x.x.x
+	 * @since 1.2.1
 	 */
 	public function missing_wc_notice() {
 		/* translators: %s WC download URL link. */


### PR DESCRIPTION
### All Submissions:

* [ ] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds a check if the `WooCommerce` class exists, if not, it shows a message. This is inspired by the bookings' [message](https://github.com/woocommerce/woocommerce-bookings/blob/abe6d802b7508fe1598406d2cf2143013ad68264/woocommerce-bookings.php#L43).

Closes #363.

### How to test the changes in this Pull Request:

1. Activate WC, WC Booking and Accommodation-Bookings.
2. Deactivate WC
3. A message should appear at the top.
<img width="707" alt="image" src="https://github.com/woocommerce/woocommerce-accommodation-bookings/assets/25176325/7e039a79-01bb-41fc-9130-c1a3bebe6c25">

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Fatal Error when WooCommerce is disabled.
