### PR TITLE
Bump WordPress Tested up to version to 6.4

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -14,7 +14,7 @@
 	<exclude-pattern>*/dist/*</exclude-pattern>
 	<exclude-pattern>*/languages/*</exclude-pattern>
 
-	<config name="minimum_supported_wp_version" value="6.1"/>
+	<config name="minimum_supported_wp_version" value="6.2"/>
 
 	<!-- ensure we are using language features according to supported PHP versions -->
 	<config name="testVersion" value="7.3-"/>

--- a/woocommerce-accommodation-bookings.php
+++ b/woocommerce-accommodation-bookings.php
@@ -8,8 +8,8 @@
  * Author URI: https://woocommerce.com
  * Text Domain: woocommerce-accommodation-bookings
  * Domain Path: /languages
- * Tested up to: 6.3
- * Requires at least: 6.1
+ * Tested up to: 6.4
+ * Requires at least: 6.2
  * WC tested up to: 8.0
  * WC requires at least: 7.8
  * Requires PHP: 7.3


### PR DESCRIPTION
### All Submissions:

* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

- Bump WordPress Tested up to version 6.3 to 6.4
- Bump WordPress Requires at least 6.1 to 6.2


Closes #383 

### Steps to test the changes in this Pull Request:

1. Run the e2e test using GitHub action to test this PR.
2. All tests should be passed. 
3. Manual Test - Plugin should give Notice when using an unsupported version of WordPress. 

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Dev - Bump WordPress "tested up to" version 6.4.
> Dev - Bump WordPress minimum supported version to 6.2.
