### PR TITLE
Fix e2e tests: Update default behavior to use a block-based cart and checkout.

### DIFF
--- a/tests/e2e/specs/order.spec.js
+++ b/tests/e2e/specs/order.spec.js
@@ -74,24 +74,40 @@ test.describe('Order Tests', () => {
 		// Verify Check-In and Check-Out Date and Time Display on Cart Page.
 		await page.goto('/cart');
 		await expect(
-			page.locator('dl.variation dd.variation-Check-in p').first()
+			page
+				.locator(
+					'.wc-block-components-product-details__check-in .wc-block-components-product-details__value'
+				)
+				.first()
 		).toContainText(checkInTime);
 		await expect(
-			page.locator('dl.variation dd.variation-Check-out p').first()
+			page
+				.locator(
+					'.wc-block-components-product-details__check-out .wc-block-components-product-details__value'
+				)
+				.first()
 		).toContainText(checkOutTime);
 
 		// Verify Check-In and Check-Out Date and Time Display on Checkout Page.
 		await page.goto('/checkout');
 		await expect(
-			page.locator('dl.variation dd.variation-Check-in p').first()
+			page
+				.locator(
+					'.wc-block-components-product-details__check-in .wc-block-components-product-details__value'
+				)
+				.first()
 		).toContainText(checkInTime);
 		await expect(
-			page.locator('dl.variation dd.variation-Check-out p').first()
+			page
+				.locator(
+					'.wc-block-components-product-details__check-out .wc-block-components-product-details__value'
+				)
+				.first()
 		).toContainText(checkOutTime);
 
 		// Verify Check-In and Check-Out Date and Time Display on Order Received Page.
-		await fillBillingDetails(page, customer.billing);
-		await placeOrder(page);
+		await fillBillingDetails(page, customer.billing, true);
+		await placeOrder(page, true);
 		await expect(
 			page
 				.locator('ul.wc-booking-summary-list .booking-start-date')
@@ -130,8 +146,8 @@ test.describe('Order Tests', () => {
 
 		// Place order and verify booking details in confirmation email.
 		await page.goto('/checkout');
-		await fillBillingDetails(page, customer.billing);
-		const orderId = await placeOrder(page);
+		await fillBillingDetails(page, customer.billing, true);
+		const orderId = await placeOrder(page, true);
 		await api.update.order({
 			id: orderId,
 			status: 'completed',

--- a/tests/e2e/specs/product.spec.js
+++ b/tests/e2e/specs/product.spec.js
@@ -244,11 +244,15 @@ test.describe('Product Tests', () => {
 
 		// Verify Accommodation Booking Process for Slot Requiring Confirmation
 		await page.goto('/checkout');
-		await expect(page.locator('#place_order')).toContainText(
-			'Request Confirmation'
-		);
-		await fillBillingDetails(page, customer.billing);
-		await placeOrder(page);
+		await expect(
+			page.locator(
+				'button.wc-block-components-checkout-place-order-button'
+			)
+		).toContainText('Request Confirmation');
+		await fillBillingDetails(page, customer.billing, true);
+		await page
+			.locator('button.wc-block-components-checkout-place-order-button')
+			.click();
 		await expect(
 			page
 				.locator('.wc-booking-summary .status-pending-confirmation')
@@ -275,8 +279,8 @@ test.describe('Product Tests', () => {
 
 		// Place order
 		await page.goto('/checkout');
-		await fillBillingDetails(page, customer.billing);
-		const orderId = await placeOrder(page);
+		await fillBillingDetails(page, customer.billing, true);
+		const orderId = await placeOrder(page, true);
 
 		page.goto('/my-account/bookings/');
 		page.on('dialog', (dialog) => dialog.accept());
@@ -288,7 +292,7 @@ test.describe('Product Tests', () => {
 			.click();
 
 		await expect(
-			page.locator('.woocommerce .woocommerce-info').first()
+			page.locator('.wc-block-components-notice-banner.is-info').first()
 		).toContainText('Your booking was cancelled');
 	});
 


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
Cart and Checkout Blocks is now the default experience with WooCommerce 8.3. current e2e tests are written using locators of shortcode cart and checkout. This PR updates the locators to block-based cart and checkout to fix failing tests.

### Steps to test the changes in this Pull Request:
Make sure E2E tests run successfully locally and in GH action. 

### Changelog entry
> Dev - Update default behavior to use a block-based cart and checkout in E2E tests.