### PR TITLE
Compatibility testing with Woo 8.3

### DIFF
--- a/woocommerce-accommodation-bookings.php
+++ b/woocommerce-accommodation-bookings.php
@@ -9,9 +9,9 @@
  * Text Domain: woocommerce-accommodation-bookings
  * Domain Path: /languages
  * Tested up to: 6.3
- * Requires at least: 6.1
- * WC tested up to: 8.0
- * WC requires at least: 7.8
+ * Requires at least: 6.2
+ * WC tested up to: 8.3
+ * WC requires at least: 8.1
  * Requires PHP: 7.3
  *
  * Copyright: © 2023 WooCommerce


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

- Bump Woocommerce Tested up to version 8.3
- Bump Woocommerce Requires at least 8.1
- Bump WordPress minimum supported version to 6.2.

Closes #384 

### Steps to test the changes in this Pull Request:

1. Run the e2e test using GitHub action to test compatibility
2. All tests should be passed.

### Changelog entry
>Dev - Bump WooCommerce "tested up to" version 8.3.
>Dev - Bump WooCommerce minimum supported version to 8.1.
>Dev - Bump WordPress minimum supported version to 6.2.