### PR TITLE
Bump WooCommerce "tested up to" 8.4

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup proper PHP version
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.3
+          php-version: 7.4
           tools: composer
 
       - name: Validate composer.json and composer.lock

--- a/.github/workflows/php-compat.yml
+++ b/.github/workflows/php-compat.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup proper PHP version
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.3
+          php-version: 7.4
           tools: composer
 
       - name: Validate composer.json and composer.lock

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup proper PHP version
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.3
+          php-version: 7.4
           tools: composer
 
       - name: Validate composer.json and composer.lock

--- a/includes/class-wc-accommodation-dependencies.php
+++ b/includes/class-wc-accommodation-dependencies.php
@@ -84,8 +84,8 @@ class WC_Accommodation_Dependencies {
 			throw new Exception( __( 'Accommodation Bookings requires Bookings version 1.9+.', 'woocommerce-accommodation-bookings' ) );
 		}
 
-		if ( ! version_compare( PHP_VERSION, '7.3', '>=' ) ) {
-			throw new Exception( __( 'Accommodation Bookings requires PHP version 7.3 or above.', 'woocommerce-accommodation-bookings' ) );
+		if ( ! version_compare( PHP_VERSION, '7.4', '>=' ) ) {
+			throw new Exception( __( 'Accommodation Bookings requires PHP version 7.4 or above.', 'woocommerce-accommodation-bookings' ) );
 		}
 	}
 }

--- a/phpcs-compat.xml.dist
+++ b/phpcs-compat.xml.dist
@@ -12,5 +12,5 @@
     <exclude-pattern>tests</exclude-pattern>
     <exclude-pattern>assets</exclude-pattern>
 
-    <config name="testVersion" value="7.3-"/>
+    <config name="testVersion" value="7.4-"/>
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -17,7 +17,7 @@
 	<config name="minimum_supported_wp_version" value="6.2"/>
 
 	<!-- ensure we are using language features according to supported PHP versions -->
-	<config name="testVersion" value="7.3-"/>
+	<config name="testVersion" value="7.4-"/>
 	<rule ref="PHPCompatibilityWP" />
 	<rule ref="WordPress.WP.I18n">
 		<properties>

--- a/woocommerce-accommodation-bookings.php
+++ b/woocommerce-accommodation-bookings.php
@@ -10,9 +10,9 @@
  * Domain Path: /languages
  * Tested up to: 6.4
  * Requires at least: 6.2
- * WC tested up to: 8.3
- * WC requires at least: 8.1
- * Requires PHP: 7.3
+ * WC tested up to: 8.4
+ * WC requires at least: 8.2
+ * Requires PHP: 7.4
  *
  * Copyright: © 2023 WooCommerce
  * License: GNU General Public License v3.0


### PR DESCRIPTION
### All Submissions:

* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

- Bump WooCommerce "tested up to" version 8.4.
- Bump WooCommerce minimum supported version to 8.2.
- Bump PHP minimum supported version to 7.4.

Closes #394 

### Steps to test the changes in this Pull Request:

1. Run the e2e test using GitHub action to test this PR with WC 8.4
2. All tests should be passed. 
3. Manual Test - Plugin should give Notice when using an unsupported version of WooCommerce. 

### Changelog entry

> Dev - Bump WooCommerce "tested up to" version 8.4.
> Dev - Bump WooCommerce minimum supported version to 8.2.
> Dev - Bump PHP minimum supported version to 7.4.

