### PR TITLE
upkeep/390: Declare compatibility with WooCommerce Blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ An accommodations add-on for the WooCommerce Bookings extension.
 
 Ensure a seamless experience with WooCommerce Payments extension Version 6.3.1, offering enhanced payment options for your accommodation bookings.
 
+## WooCommerce Blocks Compatibility
+
+This extension is compatible with [WooCommerce Blocks](https://woo.com/products/woocommerce-gutenberg-products-block/).
+
 ## NPM Scripts
 
 WooCommerce Accommodation Bookings utilizes npm scripts for task management utilities.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 1.2.3 - TBD =
+* Dev - Declare compatibility with WooCommerce Blocks.
+
 = 1.2.2 - 2023-12-11 =
 * Dev - Add end-to-end tests using Playwright.
 * Dev - Update default behavior to use a block-based cart and checkout in E2E tests.

--- a/readme.txt
+++ b/readme.txt
@@ -38,6 +38,9 @@ If the prices shown on the product do not match the prices defined in the dashbo
 
 == Changelog ==
 
+= 1.2.3 - TBD =
+* Dev - Declare compatibility with WooCommerce Blocks.
+
 = 1.2.2 - 2023-12-11 =
 * Dev - Add end-to-end tests using Playwright.
 * Dev - Update default behavior to use a block-based cart and checkout in E2E tests.


### PR DESCRIPTION
Closes #390 

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Dev - Declare compatibility with WooCommerce Blocks.