### PR TITLE
Fix missing product id when getting check-in time

### DIFF
--- a/includes/class-wc-accommodation-booking-date-picker.php
+++ b/includes/class-wc-accommodation-booking-date-picker.php
@@ -118,7 +118,7 @@ class WC_Accommodation_Booking_Date_Picker {
 						continue;
 					}
 
-					$check_in_time = $product->get_check_times( 'in', $product->get_id() );
+					$check_in_time = WC_Product_Accommodation_Booking::get_check_times( 'in' , $product->get_id());
 					if ( 'in' === $which ) {
 						$check_time = strtotime( '-1 day ' . $check_in_time, $time );
 					} else {
@@ -160,7 +160,7 @@ class WC_Accommodation_Booking_Date_Picker {
 				foreach ( $times as $time ) {
 					$day = date( 'Y-n-j', $time );
 
-					$check_in_time = $product->get_check_times( 'in' );
+					$check_in_time = WC_Product_Accommodation_Booking::get_check_times( 'in' , $product->get_id());
 					if ( 'in' === $which ) {
 						$check_time = strtotime( $check_in_time, $time );
 					} else {

--- a/includes/class-wc-accommodation-booking-date-picker.php
+++ b/includes/class-wc-accommodation-booking-date-picker.php
@@ -118,7 +118,7 @@ class WC_Accommodation_Booking_Date_Picker {
 						continue;
 					}
 
-					$check_in_time = WC_Product_Accommodation_Booking::get_check_times( 'in' , $product->get_id());
+					$check_in_time = WC_Product_Accommodation_Booking::get_check_times( 'in', $product->get_id() );
 					if ( 'in' === $which ) {
 						$check_time = strtotime( '-1 day ' . $check_in_time, $time );
 					} else {
@@ -160,7 +160,7 @@ class WC_Accommodation_Booking_Date_Picker {
 				foreach ( $times as $time ) {
 					$day = date( 'Y-n-j', $time );
 
-					$check_in_time = WC_Product_Accommodation_Booking::get_check_times( 'in' , $product->get_id());
+					$check_in_time = WC_Product_Accommodation_Booking::get_check_times( 'in', $product->get_id() );
 					if ( 'in' === $which ) {
 						$check_time = strtotime( $check_in_time, $time );
 					} else {


### PR DESCRIPTION
Fix missing product id when getting check-in time
Apply same code style within file

### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

Fix missing product id when getting check-in time
Apply same code style (call static method) within file


### Changelog entry
> Fix - Missing product ID when getting check-in time.
> Dev - Apply same code style (call static method) within file.
