### PR TITLE
Compatibility testing with Woo 8.5

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Plugin Name ===
 Contributors:  woocommerce, automattic, woothemes, jshreve, akeda, bor0, jessepearson, laurendavissmith001, royho
 Tags: woocommerce, bookings, accommodations
-Requires at least: 6.2
+Requires at least: 6.3
 Tested up to: 6.4
 Stable tag: 1.2.3
 License: GNU General Public License v3.0

--- a/woocommerce-accommodation-bookings.php
+++ b/woocommerce-accommodation-bookings.php
@@ -9,9 +9,9 @@
  * Text Domain: woocommerce-accommodation-bookings
  * Domain Path: /languages
  * Tested up to: 6.4
- * Requires at least: 6.2
- * WC tested up to: 8.4
- * WC requires at least: 8.2
+ * Requires at least: 6.3
+ * WC tested up to: 8.5
+ * WC requires at least: 8.3
  * Requires PHP: 7.4
  *
  * Copyright: © 2023 WooCommerce


### PR DESCRIPTION
### All Submissions:

* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

- Bump WooCommerce "tested up to" version 8.5.
- Bump WooCommerce minimum supported version to 8.3.
- Bump WordPress minimum supported version to 6.3.

Closes #403 

### Steps to test the changes in this Pull Request:

1. Run the e2e test using GitHub action to test this PR with WC 8.5
2. All tests should be passed. 
3. Manual Test - The plugin should give Notice when using an unsupported version of WooCommerce and WordPress. 

### Changelog entry

> Dev - Bump WooCommerce "tested up to" version 8.5.
> Dev - Bump WooCommerce minimum supported version to 8.3.
> Dev - Bump WordPress minimum supported version to 6.3.

