### PR TITLE
Compatibility testing with Woo 8.6

### DIFF
--- a/tests/e2e/specs/product.spec.js
+++ b/tests/e2e/specs/product.spec.js
@@ -292,8 +292,8 @@ test.describe('Product Tests', () => {
 			.click();
 
 		await expect(
-			page.locator('.wc-block-components-notice-banner.is-info').first()
-		).toContainText('Your booking was cancelled');
+			page.getByText('Your booking was cancelled').first()
+		).toBeVisible();
 	});
 
 	test('Availability > Bookings Can Be Made Starting - Month/Week/Day - into the future Setting - @foundational', async ({

--- a/woocommerce-accommodation-bookings.php
+++ b/woocommerce-accommodation-bookings.php
@@ -10,8 +10,8 @@
  * Domain Path: /languages
  * Tested up to: 6.4
  * Requires at least: 6.3
- * WC tested up to: 8.5
- * WC requires at least: 8.3
+ * WC tested up to: 8.6
+ * WC requires at least: 8.4
  * PHP tested up to: 8.3
  * Requires PHP: 7.4
  *


### PR DESCRIPTION
### All Submissions:

* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

- Bump WooCommerce "tested up to" version 8.6.
- Bump WooCommerce minimum supported version to 8.4.

Closes https://github.com/woocommerce/woocommerce-accommodation-bookings/issues/411  

### Steps to test the changes in this Pull Request:

1. Run the e2e test using GitHub action to test this PR with WC 8.6
2. All tests should be passed. 
3. Manual Test - The plugin should give Notice when using an unsupported version of WooCommerce and WordPress. 

### Changelog entry

> Dev - Bump WooCommerce "tested up to" version 8.6.
> Dev - Bump WooCommerce minimum supported version to 8.4.

