### PR TITLE
Compatibility testing with Woo 8.7 and WordPress 6.5

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -27,3 +27,4 @@ jest-puppeteer.config.js export-ignore
 .nvmrc export-ignore
 assets export-ignore
 .wp-env.json export-ignore
+.wp-env.override.json export-ignore

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -50,11 +50,15 @@ jobs:
       - name: Install Playwright Browsers
         run: npx playwright install chromium
 
+      - name: Set the core version
+        if: "${{ contains(github.event.pull_request.labels.*.name, 'needs: WP RC test') }}"
+        id: run-rc-test
+        run: ./tests/e2e/bin/set-core-version.js WordPress/WordPress#master
+
       - name: Setup WP environment
         run: |
           npm run env:install-plugins
           npm run env:start
-
 
       - name: Run E2E Foundational Test
         id: e2e_tests

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ Thumbs.db
 .project
 .settings*
 .vscode
+.wp-env.override.json
 sftp-config.json
 /deploy/
 /wc-apidocs/

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,8 +1,7 @@
 {
   "plugins": [
     "https://downloads.wordpress.org/plugin/woocommerce.zip",
-    "https://downloads.wordpress.org/plugin/email-log.zip",
-    "."
+    "https://downloads.wordpress.org/plugin/email-log.zip"
   ],
   "themes": [
     "https://downloads.wordpress.org/theme/storefront.zip"
@@ -10,7 +9,8 @@
   "env": {
     "tests": {
       "mappings": {
-        "wp-cli.yml": "./tests/e2e/bin/wp-cli.yml"
+        "wp-cli.yml": "./tests/e2e/bin/wp-cli.yml",
+        "wp-content/plugins/woocommerce-accommodation-bookings": "."
       }
     }
   }

--- a/tests/e2e/bin/initialize.sh
+++ b/tests/e2e/bin/initialize.sh
@@ -21,3 +21,4 @@ wp-env run tests-cli wp user create customer customer@bookingstestsuite.com --us
 
 # Install and activate WooCommerce Bookings
 wp-env run tests-cli wp plugin install --activate ./wp-content/plugins/woocommerce-accommodation-bookings/woocommerce-bookings.zip
+wp-env run tests-cli wp plugin activate woocommerce-accommodation-bookings

--- a/tests/e2e/bin/set-core-version.js
+++ b/tests/e2e/bin/set-core-version.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+const fs = require( 'fs' );
+const { exit } = require( 'process' );
+
+const path = `${ process.cwd() }/.wp-env.override.json`;
+
+// eslint-disable-next-line import/no-dynamic-require
+const config = fs.existsSync( path ) ? require( path ) : {};
+
+const args = process.argv.slice( 2 );
+
+if ( args.length === 0 ) exit( 0 );
+
+if ( args[ 0 ] === 'latest' ) {
+	if ( fs.existsSync( path ) ) {
+		fs.unlinkSync( path );
+	}
+	exit( 0 );
+}
+
+config.core = args[ 0 ];
+
+// eslint-disable-next-line no-useless-escape
+if ( ! config.core.match( /^WordPress\/WordPress\#/ ) ) {
+	config.core = `WordPress/WordPress#${ config.core }`;
+}
+
+try {
+	fs.writeFileSync( path, JSON.stringify( config ) );
+} catch ( err ) {
+	// eslint-disable-next-line no-console
+	console.error( err );
+}

--- a/tests/e2e/specs/admin.spec.js
+++ b/tests/e2e/specs/admin.spec.js
@@ -24,37 +24,6 @@ test.describe('Admin Tests', () => {
 		).toBeVisible();
 	});
 
-	test('Store admin can see a notice when the WooCommerce Bookings is not active - @foundational', async ({
-		page,
-	}) => {
-		await page.goto('/wp-admin/plugins.php');
-
-		// Deactivate Bookings plugin
-		page.getByRole('link', {
-			name: 'Deactivate WooCommerce Bookings',
-			exact: true,
-		}).click();
-
-		await expect(
-			page.locator('.error p', {
-				hasText:
-					'Accommodation Bookings requires Bookings plugin activated.',
-			})
-		).toBeVisible();
-
-		await page.goto('/wp-admin/plugins.php');
-		// Activate Bookings plugin,
-		page.getByRole('link', {
-			name: 'Activate WooCommerce Bookings',
-			exact: true,
-		}).click();
-		await expect(
-			page.locator('#message.updated.notice.is-dismissible', {
-				hasText: 'Plugin activated.',
-			})
-		).toBeVisible();
-	});
-
 	test('Store admin can configure accommodation settings - @foundational', async ({
 		page,
 	}) => {

--- a/woocommerce-accommodation-bookings.php
+++ b/woocommerce-accommodation-bookings.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * Plugin Name: WooCommerce Accommodation Bookings
+ * Requires Plugins: woocommerce, woocommerce-bookings
  * Plugin URI: https://woocommerce.com/products/woocommerce-accommodation-bookings/
  * Description: An accommodations add-on for the WooCommerce Bookings extension.
  * Version: 1.2.5
@@ -8,10 +9,10 @@
  * Author URI: https://woocommerce.com
  * Text Domain: woocommerce-accommodation-bookings
  * Domain Path: /languages
- * Tested up to: 6.4
+ * Tested up to: 6.5
  * Requires at least: 6.3
- * WC tested up to: 8.6
- * WC requires at least: 8.4
+ * WC tested up to: 8.7
+ * WC requires at least: 8.5
  * PHP tested up to: 8.3
  * Requires PHP: 7.4
  *


### PR DESCRIPTION
### All Submissions:

* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

- Added Plugin Require Header
- Bump WooCommerce "tested up to" version 8.7.
- Bump WooCommerce minimum supported version to 8.5
- Bump WordPress "tested up to" version 6.5.
- Bump WordPress minimum supported version to 6.3. 

Closes https://github.com/woocommerce/woocommerce-accommodation-bookings/issues/416

### Steps to test the changes in this Pull Request:

1. Run the e2e test using GitHub action to test this PR 
2. All tests should be passed. 
3. Manual Test - The plugin should give Notice when using an unsupported version of WooCommerce and WordPress. 

### Changelog entry

> Dev - Bump WooCommerce "tested up to" version 8.7.
> Dev - Bump WooCommerce minimum supported version to 8.5
> Dev - Bump WordPress "tested up to" version 6.5.
> Dev - Bump WordPress minimum supported version to 6.3.

