### PR TITLE
Compatibility testing with Woo 8.8

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:  woocommerce, automattic, woothemes, jshreve, akeda, bor0, jessepearson, laurendavissmith001, royho
 Tags: woocommerce, bookings, accommodations
 Requires at least: 6.3
-Tested up to: 6.4
+Tested up to: 6.5
 Stable tag: 1.2.5
 License: GNU General Public License v3.0
 License URI: http://www.gnu.org/licenses/gpl-3.0.html

--- a/woocommerce-accommodation-bookings.php
+++ b/woocommerce-accommodation-bookings.php
@@ -11,8 +11,8 @@
  * Domain Path: /languages
  * Tested up to: 6.5
  * Requires at least: 6.3
- * WC tested up to: 8.7
- * WC requires at least: 8.5
+ * WC tested up to: 8.8
+ * WC requires at least: 8.6
  * PHP tested up to: 8.3
  * Requires PHP: 7.4
  *


### PR DESCRIPTION
### All Submissions:

* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---
### Changes proposed in this Pull Request:

- Bump WooCommerce "tested up to" version 8.8
- Bump WooCommerce minimum supported version to 8.6
- Bump WordPress "tested up to" version 6.5


Closes https://github.com/woocommerce/woocommerce-accommodation-bookings/issues/422

### Steps to test the changes in this Pull Request:

1. Run the e2e test using GitHub action to test this PR 
2. All tests should be passed. 
3. Manual Test - The plugin should give Notice when using an unsupported version of WooCommerce and WordPress. 

### Changelog entry

> Dev - Bump WooCommerce "tested up to" version 8.8.
> Dev - Bump WooCommerce minimum supported version to 8.6.
> Dev - Bump WordPress "tested up to" version 6.5.

