### PR TITLE
Fix display of 2 checkbox options in Accomodation product

### DIFF
--- a/includes/admin/views/html-accommodation-booking-data.php
+++ b/includes/admin/views/html-accommodation-booking-data.php
@@ -48,14 +48,14 @@
 			'id'          => '_wc_accommodation_booking_requires_confirmation',
 			'label'       => __( 'Requires confirmation?', 'woocommerce-accommodation-bookings' ),
 			'description' => __( 'Check this box if the booking requires admin approval/confirmation. Payment will not be taken during checkout.', 'woocommerce-accommodation-bookings' ),
-			'value'       => get_post_meta( $post_id, '_wc_booking_requires_confirmation', true ),
-		) );
+			'value'       => wc_bookings_string_to_bool( get_post_meta( $post_id, '_wc_booking_requires_confirmation', true ) ) ? 'yes' : 'no',
+        ) );
 
 		woocommerce_wp_checkbox( array(
 			'id'          => '_wc_accommodation_booking_user_can_cancel',
 			'label'       => __( 'Can be cancelled?', 'woocommerce-accommodation-bookings' ),
 			'description' => __( 'Check this box if the booking can be cancelled by the customer after it has been purchased. A refund will not be sent automatically.', 'woocommerce-accommodation-bookings' ),
-			'value'       => get_post_meta( $post_id, '_wc_booking_user_can_cancel', true ),
+            'value'       => wc_bookings_string_to_bool( get_post_meta( $post_id, '_wc_booking_user_can_cancel', true ) ) ? 'yes' : 'no',
 		) );
 
 		$cancel_limit      = max( absint( get_post_meta( $post_id, '_wc_booking_cancel_limit', true ) ), 1 );

--- a/includes/admin/views/html-accommodation-booking-data.php
+++ b/includes/admin/views/html-accommodation-booking-data.php
@@ -5,62 +5,72 @@
 		$min_duration = absint( get_post_meta( $post_id, '_wc_booking_min_duration', true ) );
 		$max_duration = absint( get_post_meta( $post_id, '_wc_booking_max_duration', true ) );
 
-		woocommerce_wp_text_input( array(
-			'id'                => '_wc_accommodation_booking_min_duration',
-			'label'             => __( 'Minimum number of nights allowed in a booking', 'woocommerce-accommodation-bookings' ),
-			'description'       => __( 'The minimum allowed duration the user can stay.', 'woocommerce-accommodation-bookings' ),
-			'value'             => ( empty( $min_duration ) ? 1 : $min_duration ),
-			'desc_tip'          => true,
-			'type'              => 'number',
-			'custom_attributes' => array(
-				'min'  => '',
-				'step' => '1'
+		woocommerce_wp_text_input(
+			array(
+				'id'                => '_wc_accommodation_booking_min_duration',
+				'label'             => __( 'Minimum number of nights allowed in a booking', 'woocommerce-accommodation-bookings' ),
+				'description'       => __( 'The minimum allowed duration the user can stay.', 'woocommerce-accommodation-bookings' ),
+				'value'             => ( empty( $min_duration ) ? 1 : $min_duration ),
+				'desc_tip'          => true,
+				'type'              => 'number',
+				'custom_attributes' => array(
+					'min'  => '',
+					'step' => '1',
+				),
 			)
-		) );
+		);
 
-		woocommerce_wp_text_input( array(
-			'id'                => '_wc_accommodation_booking_max_duration',
-			'label'             => __( 'Maximum number of nights allowed in a booking', 'woocommerce-accommodation-bookings' ),
-			'description'       => __( 'The maximum allowed duration the user can stay.', 'woocommerce-accommodation-bookings' ),
-			'value'             => ( empty( $max_duration ) ? 7 : $max_duration ),
-			'desc_tip'          => true,
-			'type'              => 'number',
-			'custom_attributes' => array(
-				'min'  => '1',
-				'step' => '1'
+		woocommerce_wp_text_input(
+			array(
+				'id'                => '_wc_accommodation_booking_max_duration',
+				'label'             => __( 'Maximum number of nights allowed in a booking', 'woocommerce-accommodation-bookings' ),
+				'description'       => __( 'The maximum allowed duration the user can stay.', 'woocommerce-accommodation-bookings' ),
+				'value'             => ( empty( $max_duration ) ? 7 : $max_duration ),
+				'desc_tip'          => true,
+				'type'              => 'number',
+				'custom_attributes' => array(
+					'min'  => '1',
+					'step' => '1',
+				),
 			)
-		) );
+		);
 
-		woocommerce_wp_select( array(
-			'id'          => '_wc_accommodation_booking_calendar_display_mode',
-			'label'       => __( 'Calendar display mode', 'woocommerce-accommodation-bookings' ),
-			'description' => __( 'Choose how the calendar is displayed on the booking form.', 'woocommerce-accommodation-bookings' ),
-			'value'       => get_post_meta( $post_id, '_wc_booking_calendar_display_mode', true ),
-			'options'     => array(
-				''               => __( 'Display calendar on click', 'woocommerce-accommodation-bookings' ),
-				'always_visible' => __( 'Calendar always visible', 'woocommerce-accommodation-bookings' )
-			),
-			'desc_tip'    => true,
-			'class'       => 'select'
-		) );
+		woocommerce_wp_select(
+			array(
+				'id'          => '_wc_accommodation_booking_calendar_display_mode',
+				'label'       => __( 'Calendar display mode', 'woocommerce-accommodation-bookings' ),
+				'description' => __( 'Choose how the calendar is displayed on the booking form.', 'woocommerce-accommodation-bookings' ),
+				'value'       => get_post_meta( $post_id, '_wc_booking_calendar_display_mode', true ),
+				'options'     => array(
+					''               => __( 'Display calendar on click', 'woocommerce-accommodation-bookings' ),
+					'always_visible' => __( 'Calendar always visible', 'woocommerce-accommodation-bookings' ),
+				),
+				'desc_tip'    => true,
+				'class'       => 'select',
+			)
+		);
 
-		woocommerce_wp_checkbox( array(
-			'id'          => '_wc_accommodation_booking_requires_confirmation',
-			'label'       => __( 'Requires confirmation?', 'woocommerce-accommodation-bookings' ),
-			'description' => __( 'Check this box if the booking requires admin approval/confirmation. Payment will not be taken during checkout.', 'woocommerce-accommodation-bookings' ),
-			'value'       => wc_bookings_string_to_bool( get_post_meta( $post_id, '_wc_booking_requires_confirmation', true ) ) ? 'yes' : 'no',
-        ) );
+		woocommerce_wp_checkbox(
+			array(
+				'id'          => '_wc_accommodation_booking_requires_confirmation',
+				'label'       => __( 'Requires confirmation?', 'woocommerce-accommodation-bookings' ),
+				'description' => __( 'Check this box if the booking requires admin approval/confirmation. Payment will not be taken during checkout.', 'woocommerce-accommodation-bookings' ),
+				'value'       => wc_bookings_string_to_bool( get_post_meta( $post_id, '_wc_booking_requires_confirmation', true ) ) ? 'yes' : 'no',
+			)
+		);
 
-		woocommerce_wp_checkbox( array(
-			'id'          => '_wc_accommodation_booking_user_can_cancel',
-			'label'       => __( 'Can be cancelled?', 'woocommerce-accommodation-bookings' ),
-			'description' => __( 'Check this box if the booking can be cancelled by the customer after it has been purchased. A refund will not be sent automatically.', 'woocommerce-accommodation-bookings' ),
-            'value'       => wc_bookings_string_to_bool( get_post_meta( $post_id, '_wc_booking_user_can_cancel', true ) ) ? 'yes' : 'no',
-		) );
+		woocommerce_wp_checkbox(
+			array(
+				'id'          => '_wc_accommodation_booking_user_can_cancel',
+				'label'       => __( 'Can be cancelled?', 'woocommerce-accommodation-bookings' ),
+				'description' => __( 'Check this box if the booking can be cancelled by the customer after it has been purchased. A refund will not be sent automatically.', 'woocommerce-accommodation-bookings' ),
+				'value'       => wc_bookings_string_to_bool( get_post_meta( $post_id, '_wc_booking_user_can_cancel', true ) ) ? 'yes' : 'no',
+			)
+		);
 
 		$cancel_limit      = max( absint( get_post_meta( $post_id, '_wc_booking_cancel_limit', true ) ), 1 );
 		$cancel_limit_unit = get_post_meta( $post_id, '_wc_booking_cancel_limit_unit', true );
-	?>
+		?>
 	<p class="form-field accommodation-booking-cancel-limit">
 		<label for="_wc_accommodation_booking_cancel_limit"><?php esc_html_e( 'Cancellation up till', 'woocommerce-accommodation-bookings' ); ?></label>
 		<input type="number" name="_wc_accommodation_booking_cancel_limit" id="_wc_accommodation_booking_cancel_limit" value="<?php echo esc_attr( $cancel_limit ); ?>" step="1" min="1" style="margin-right: 7px; width: 4em;">


### PR DESCRIPTION
Fix display of checkbox options "user_can_cancel" & "requires_confirmation" in admin when db value is boolean

### All Submissions:

* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

WC_Product_Booking following methods use boolean values, our Accomodation booking plugin must be able to understand boolean values from database (and not only "yes", "no")
```

	/**
	 * Get requires_confirmation.
	 *
	 * @param  string $context
	 * @return boolean
	 */
	public function get_requires_confirmation( $context = 'view' ) {
		return $this->get_prop( 'requires_confirmation', $context );
	}

	/**
	 * Set requires_confirmation.
	 *
	 * @param boolean $value
	 */
	public function set_requires_confirmation( $value ) {
		$this->set_prop( 'requires_confirmation', wc_bookings_string_to_bool( $value ) );
	}

```

### Steps to test the changes in this Pull Request:

1. Woocommerce > Products > Add new
2. Fill a title, select "Bookable product", check the "Requires confirmation?" checbox and save
3. _wc_booking_requires_confirmation	= **1** in database

--
   
1. Woocommerce > Products > Add new
2. Fill a title, select "Accomodation product", check the "Requires confirmation?" checbox and save
3. _wc_booking_requires_confirmation	= **yes** in database

At this point, I'm a bit lost. I guess the plugin should follow the "base" require_confirmation type but I'm not sure anymore if my fix is the good way to do so.

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Fix  - Display of 2 checkbox options in Accommodation product.
