### PR TITLE
Help Finding Product Type Selector

### DIFF
--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -9,8 +9,8 @@
  * @return {boolean} Returns true if the product is a accommodation booking product type.
  */
 export function is_product_type_accommodation_booking($booking_form) {
-	return $booking_form
-		.closest('.product.product-type-accommodation-booking').length;
+	return $booking_form.closest('.product.product-type-accommodation-booking')
+		.length;
 }
 
 /**

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -10,8 +10,7 @@
  */
 export function is_product_type_accommodation_booking($booking_form) {
 	return $booking_form
-		.closest('.product')
-		.hasClass('product-type-accommodation-booking');
+		.closest('.product.product-type-accommodation-booking').length;
 }
 
 /**

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -9,8 +9,10 @@
  * @return {boolean} Returns true if the product is a accommodation booking product type.
  */
 export function is_product_type_accommodation_booking($booking_form) {
-	return $booking_form.closest('.product.product-type-accommodation-booking')
-		.length > 0;
+	return (
+		$booking_form.closest('.product.product-type-accommodation-booking')
+			.length > 0
+	);
 }
 
 /**

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -10,7 +10,7 @@
  */
 export function is_product_type_accommodation_booking($booking_form) {
 	return $booking_form.closest('.product.product-type-accommodation-booking')
-		.length;
+		.length > 0;
 }
 
 /**


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

After a thorough debugging and investigation, it is found that the search for the selector for the product type was incorrectly coded (or maybe the HTML changed in recent WP/Woo releases). This PR tweaks the code so that the selector is found and the proper class is applied to the dates, making them display as fully booked when required, ultimately fixing the reported issue (#417).

Note: in the reported issue it is mentioned that it occurs only when the "Display visitor's local time" setting is enabled but it was occurring regardless of this setting.

Closes #417.

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

1. Create an accommodation product for day booking.
2. Set "Number of rooms available" to 1 in availability settings.
3. Book a room for a day, for example, the 25th of the month.
4. After successful booking placement, return to the calendar and note that the 25th should appear as booked, not available to select as start date.

### Changelog entry
> Fix - Unavailable accommodation days appear available even when booked.
