### PR TITLE
Ensure the plugin doesn't have issues when released on WordPress.org

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== Plugin Name ===
+=== WooCommerce Accommodation Bookings ===
 Contributors:  woocommerce, automattic
 Tags: woocommerce, bookings, accommodations
 Requires at least: 6.3

--- a/woocommerce-accommodation-bookings.php
+++ b/woocommerce-accommodation-bookings.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: WooCommerce Accommodation Bookings
- * Requires Plugins: woocommerce, woocommerce-bookings
+ * Requires Plugins: woocommerce
  * Plugin URI: https://woocommerce.com/products/woocommerce-accommodation-bookings/
  * Description: An accommodations add-on for the WooCommerce Bookings extension.
  * Version: 1.2.6


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

During the last release to WordPress.org, two issues were encountered. Those were fixed directly in the codebase that gets deployed to WordPress.org so bringing those changes over to this repo:

1. Ensure we have a proper plugin name in the `readme.txt` file. This has been set for 9+ years so not sure why it's causing an issue now but it's a good thing to fix anyway
2. Remove `woocommerce-bookings` from the list of `Required Plugins`. Bookings is required but because Bookings isn't hosted on WordPress.org, it's been noted that this can cause problems (see https://make.wordpress.org/core/2024/03/05/introducing-plugin-dependencies-in-wordpress-6-5/)

### Steps to test the changes in this Pull Request:

Nothing really needed to test here

### Changelog entry

> Dev - Add proper plugin name to the `readme.txt`. Remove Bookings from our required plugins list as it's not hosted on WordPress.org.
