### PR TITLE
Compatibility testing with WC 9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@playwright/test": "^1.37.1",
         "@woocommerce/eslint-plugin": "^2.2.0",
         "@woocommerce/woocommerce-rest-api": "^1.0.1",
-        "@wordpress/env": "^8.7.0",
+        "@wordpress/env": "^9.10.0",
         "@wordpress/i18n": "^4.25.0",
         "@wordpress/prettier-config": "^2.8.0",
         "@wordpress/scripts": "^25.2.0",
@@ -4211,14 +4211,14 @@
       }
     },
     "node_modules/@wordpress/env": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-8.7.0.tgz",
-      "integrity": "sha512-cqjDjFFLZ8691mzsuPaakoNbUJ5d6DNNRMyN6UZefLGKhthlqmyK5DqzXZUzCr9cgF/kdc//v3ZmBy9nywBYSA==",
+      "version": "9.10.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-9.10.0.tgz",
+      "integrity": "sha512-GqUg1XdrUXI3l5NhHhEZisrccW+VPqJSU5xO1IXybI6KOvmSecidxWEqlMj26vzu2P5aLCWZcx28QkrrY3jvdg==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "copy-dir": "^1.3.0",
-        "docker-compose": "^0.22.2",
+        "docker-compose": "^0.24.3",
         "extract-zip": "^1.6.7",
         "got": "^11.8.5",
         "inquirer": "^7.1.0",
@@ -7754,12 +7754,27 @@
       }
     },
     "node_modules/docker-compose": {
-      "version": "0.22.2",
-      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.22.2.tgz",
-      "integrity": "sha512-iXWb5+LiYmylIMFXvGTYsjI1F+Xyx78Jm/uj1dxwwZLbWkUdH6yOXY5Nr3RjbYX15EgbGJCq78d29CmWQQQMPg==",
+      "version": "0.24.8",
+      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.24.8.tgz",
+      "integrity": "sha512-plizRs/Vf15H+GCVxq2EUvyPK7ei9b/cVesHvjnX4xaXjM9spHe2Ytq0BitndFgvTJ3E3NljPNUEl7BAN43iZw==",
       "dev": true,
+      "dependencies": {
+        "yaml": "^2.2.2"
+      },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/docker-compose/node_modules/yaml": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.5.tgz",
+      "integrity": "sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==",
+      "dev": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/doctrine": {
@@ -21860,14 +21875,14 @@
       }
     },
     "@wordpress/env": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-8.7.0.tgz",
-      "integrity": "sha512-cqjDjFFLZ8691mzsuPaakoNbUJ5d6DNNRMyN6UZefLGKhthlqmyK5DqzXZUzCr9cgF/kdc//v3ZmBy9nywBYSA==",
+      "version": "9.10.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-9.10.0.tgz",
+      "integrity": "sha512-GqUg1XdrUXI3l5NhHhEZisrccW+VPqJSU5xO1IXybI6KOvmSecidxWEqlMj26vzu2P5aLCWZcx28QkrrY3jvdg==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
         "copy-dir": "^1.3.0",
-        "docker-compose": "^0.22.2",
+        "docker-compose": "^0.24.3",
         "extract-zip": "^1.6.7",
         "got": "^11.8.5",
         "inquirer": "^7.1.0",
@@ -24471,10 +24486,21 @@
       }
     },
     "docker-compose": {
-      "version": "0.22.2",
-      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.22.2.tgz",
-      "integrity": "sha512-iXWb5+LiYmylIMFXvGTYsjI1F+Xyx78Jm/uj1dxwwZLbWkUdH6yOXY5Nr3RjbYX15EgbGJCq78d29CmWQQQMPg==",
-      "dev": true
+      "version": "0.24.8",
+      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.24.8.tgz",
+      "integrity": "sha512-plizRs/Vf15H+GCVxq2EUvyPK7ei9b/cVesHvjnX4xaXjM9spHe2Ytq0BitndFgvTJ3E3NljPNUEl7BAN43iZw==",
+      "dev": true,
+      "requires": {
+        "yaml": "^2.2.2"
+      },
+      "dependencies": {
+        "yaml": {
+          "version": "2.4.5",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.5.tgz",
+          "integrity": "sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==",
+          "dev": true
+        }
+      }
     },
     "doctrine": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@playwright/test": "^1.37.1",
     "@woocommerce/eslint-plugin": "^2.2.0",
     "@woocommerce/woocommerce-rest-api": "^1.0.1",
-    "@wordpress/env": "^8.7.0",
+    "@wordpress/env": "^9.10.0",
     "@wordpress/i18n": "^4.25.0",
     "@wordpress/prettier-config": "^2.8.0",
     "@wordpress/scripts": "^25.2.0",

--- a/tests/e2e/utils/index.js
+++ b/tests/e2e/utils/index.js
@@ -337,6 +337,15 @@ export async function blockFillBillingDetails(page, customerDetails) {
 	await page
 		.locator('#billing-address_1')
 		.fill(customerDetails.addressfirstline);
+	if (
+		await page
+			.locator('.wc-block-components-address-form__address_2-toggle')
+			.isVisible()
+	) {
+		await page
+			.locator('.wc-block-components-address-form__address_2-toggle')
+			.click();
+	}
 	await page
 		.locator('#billing-address_2')
 		.fill(customerDetails.addresssecondline);

--- a/woocommerce-accommodation-bookings.php
+++ b/woocommerce-accommodation-bookings.php
@@ -10,9 +10,9 @@
  * Text Domain: woocommerce-accommodation-bookings
  * Domain Path: /languages
  * Tested up to: 6.5
- * Requires at least: 6.3
- * WC tested up to: 8.9
- * WC requires at least: 8.7
+ * Requires at least: 6.4
+ * WC tested up to: 9.0
+ * WC requires at least: 8.8
  * PHP tested up to: 8.3
  * Requires PHP: 7.4
  *


### PR DESCRIPTION
### All Submissions:

* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---
### Changes proposed in this Pull Request:

- Bump WooCommerce "tested up to" version 9.0
- Bump WooCommerce minimum supported version to 8.8
- Bump WordPress minimum supported version to 6.4


Closes https://github.com/woocommerce/woocommerce-accommodation-bookings/issues/439

### Steps to test the changes in this Pull Request:

1. Run the e2e test using GitHub action to test this PR 
2. All tests should be passed. 

### Changelog entry

> Dev - Bump WooCommerce "tested up to" version 9.0
> Dev - Bump WooCommerce minimum supported version to 8.8
> Dev - Bump WordPress minimum supported version to 6.4


