### PR TITLE
Fix price sorting by fixing product_meta_lookup min_price & max_price

### DIFF
--- a/includes/admin/class-wc-accommodation-booking-rest-and-admin.php
+++ b/includes/admin/class-wc-accommodation-booking-rest-and-admin.php
@@ -325,8 +325,22 @@ class WC_Accommodation_Booking_REST_And_Admin {
 		update_post_meta( $post_id, '_manage_stock', 'no' );
 
 		// Set price so filters work - using get_base_cost().
-		$product = wc_get_product( $post_id );
-		update_post_meta( $post_id, '_price', $product->get_base_cost() );
+		$product   = wc_get_product( $post_id );
+		$base_cost = $product->get_base_cost();
+		update_post_meta( $post_id, '_price', $base_cost );
+
+		// Price has been set to cost * min_duration in meta_lookup table, needs to be updated to maintain consistency.
+		$wpdb->update(
+			$wpdb->prefix . 'wc_product_meta_lookup',
+			array(
+				'min_price' => $base_cost,
+				'max_price' => $base_cost,
+			),
+			array(
+				'product_id' => $post_id,
+			),
+			'%d'
+		);
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
Update the min_price & max_price values in wc_product_meta_lookup that has been wrongly set to unique cost times duration by the booking data store.

Closes #434 .

### Steps to test the changes in this Pull Request:
Check the "Steps to reproduce the issue" in #434 issue

### Changelog entry
> Fix - Issue with price sorting. 
