### PR TITLE
WP version bump and e2e fixes

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:  woocommerce, automattic
 Tags: woocommerce, bookings, accommodations
 Requires at least: 6.5
-Tested up to: 6.6
+Tested up to: 6.7
 Stable tag: 1.2.9
 License: GNU General Public License v3.0
 License URI: http://www.gnu.org/licenses/gpl-3.0.html

--- a/tests/e2e/global-setup.js
+++ b/tests/e2e/global-setup.js
@@ -69,7 +69,7 @@ module.exports = async (config) => {
 			await adminPage.goto(`/wp-admin`);
 			await adminPage.fill('input[name="log"]', admin.username);
 			await adminPage.fill('input[name="pwd"]', admin.password);
-			await adminPage.click('text=Log In');
+			await adminPage.locator("#wp-submit").click();
 			await adminPage.waitForLoadState('networkidle');
 			await adminPage.goto(`/wp-admin`);
 			await adminPage.waitForLoadState('domcontentloaded');
@@ -146,8 +146,8 @@ module.exports = async (config) => {
 			await customerPage.goto(`/wp-admin`);
 			await customerPage.fill('input[name="log"]', customer.username);
 			await customerPage.fill('input[name="pwd"]', customer.password);
-			await customerPage.click('text=Log In');
-			await adminPage.waitForLoadState('networkidle');
+			await customerPage.locator("#wp-submit").click();
+			await customerPage.waitForLoadState('networkidle');
 
 			await customerPage.goto(`/my-account`);
 			await expect(

--- a/tests/e2e/global-teardown.js
+++ b/tests/e2e/global-teardown.js
@@ -21,7 +21,7 @@ module.exports = async (config) => {
       await adminPage.goto(`/wp-admin`);
       await adminPage.locator('input[name="log"]').fill(admin.username);
       await adminPage.locator('input[name="pwd"]').fill(admin.password);
-      await adminPage.locator("text=Log In").click();
+      await adminPage.locator("#wp-submit").click();
       await adminPage.goto(
         `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=keys`
       );

--- a/tests/e2e/utils/index.js
+++ b/tests/e2e/utils/index.js
@@ -624,6 +624,7 @@ export async function clearEmailLogs(page) {
 	await page.goto('/wp-admin/admin.php?page=email-log');
 	const bulkAction = await page.locator('#bulk-action-selector-top');
 	if (await bulkAction.isVisible()) {
+		await page.locator('#cb-select-all-1').click();
 		await bulkAction.selectOption('el-log-list-delete-all');
 		await page.locator('#doaction').click();
 		await expect(

--- a/woocommerce-accommodation-bookings.php
+++ b/woocommerce-accommodation-bookings.php
@@ -9,7 +9,7 @@
  * Author URI: https://woocommerce.com
  * Text Domain: woocommerce-accommodation-bookings
  * Domain Path: /languages
- * Tested up to: 6.6
+ * Tested up to: 6.7
  * Requires at least: 6.5
  * WC tested up to: 9.4
  * WC requires at least: 9.2


### PR DESCRIPTION
### All Submissions:

* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

- Bump WordPress Tested up to version 6.6 to 6.7



Closes https://github.com/woocommerce/woocommerce-accommodation-bookings/issues/467 

### Steps to test the changes in this Pull Request:

1. Run the e2e test using GitHub action to test this PR.
2. All tests should be passed. 
 

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Dev - Bump WordPress "tested up to" version 6.7.


