### PR TITLE
Render uniform WP time picker over default time input element

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,7 +1,8 @@
 {
   "plugins": [
     "https://downloads.wordpress.org/plugin/woocommerce.zip",
-    "https://downloads.wordpress.org/plugin/email-log.zip"
+    "https://downloads.wordpress.org/plugin/email-log.zip",
+    "."
   ],
   "themes": [
     "https://downloads.wordpress.org/theme/storefront.zip"

--- a/README.md
+++ b/README.md
@@ -17,14 +17,6 @@ An accommodations add-on for the WooCommerce Bookings extension.
 - `npm run env:start` - Start wp-env local environment
 - `npm run start:webpack` - FE build tools
 
-## WooCommerce Payments Compatibility
-
-Ensure a seamless experience with WooCommerce Payments extension Version 6.3.1, offering enhanced payment options for your accommodation bookings.
-
-## WooCommerce Blocks Compatibility
-
-This extension is compatible with [WooCommerce Blocks](https://woo.com/products/woocommerce-gutenberg-products-block/).
-
 ## NPM Scripts
 
 WooCommerce Accommodation Bookings utilizes npm scripts for task management utilities.
@@ -32,3 +24,11 @@ WooCommerce Accommodation Bookings utilizes npm scripts for task management util
 `nvm install` - Installs the required node version.
 `npm ci` - Installs the required node modules.
 `npm run build` - Runs the tasks necessary for a release. These include building JavaScript, SASS, CSS minification, and language files.
+
+## WooCommerce Payments Compatibility
+
+Ensure a seamless experience with WooCommerce Payments extension Version 6.3.1, offering enhanced payment options for your accommodation bookings.
+
+## WooCommerce Blocks Compatibility
+
+This extension is compatible with [WooCommerce Blocks](https://woo.com/products/woocommerce-gutenberg-products-block/).

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ An accommodations add-on for the WooCommerce Bookings extension.
 - `npm run env:start` - Start wp-env local environment
 - `npm run start:webpack` - FE build tools
 
+After you build and launch the project locally you'll then have to manually install the WooCommerce Bookings plugin. You can download an install ready zip file from the [WooCommerce Bookings GitHub](https://github.com/woocommerce/woocommerce-bookings/releases).
+
+**The WooCommerce Accommodations Bookings extension can not be activated with the WooCommerce Bookings extension.**
+
 ## NPM Scripts
 
 WooCommerce Accommodation Bookings utilizes npm scripts for task management utilities.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ An accommodations add-on for the WooCommerce Bookings extension.
 - Minimum node version: 20.x
 - Minimum NPM version: 10.x
 
+## Setup
+- `nvm use`
+- `npm install`
+- `composer install`
+
+### Dev
+- `npm run env:start` - Start wp-env local environment
+- `npm run start:webpack` - FE build tools
+
 ## WooCommerce Payments Compatibility
 
 Ensure a seamless experience with WooCommerce Payments extension Version 6.3.1, offering enhanced payment options for your accommodation bookings.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ An accommodations add-on for the WooCommerce Bookings extension.
 
 After you build and launch the project locally you'll then have to manually install the WooCommerce Bookings plugin. You can download an install ready zip file from the [WooCommerce Bookings GitHub](https://github.com/woocommerce/woocommerce-bookings/releases).
 
-**The WooCommerce Accommodations Bookings extension can not be activated with the WooCommerce Bookings extension.**
+**The WooCommerce Accommodations Bookings extension can not be activated without the WooCommerce Bookings extension.**
 
 ## NPM Scripts
 

--- a/includes/admin/class-wc-accommodation-booking-admin-product-settings.php
+++ b/includes/admin/class-wc-accommodation-booking-admin-product-settings.php
@@ -218,7 +218,7 @@ class WC_Accommodation_Booking_Admin_Product_Settings extends WC_Settings_API {
 			<th scope="row" class="titledesc">
 				<label for="<?php echo esc_attr( $field_key ); ?>"><?php echo esc_html( $value['title'] ); ?></label>
 			</th>
-			<td class="wc-bookings-render-wp-time-picker forminp forminp-<?php echo esc_attr( sanitize_title( $value['type'] ) ) ?>">
+			<td class="wc-bookings-render-wp-time-picker forminp forminp-<?php echo esc_attr( sanitize_title( $value['type'] ) ); ?>">
 				<input
 					name="<?php echo esc_attr( $field_key ); ?>"
 					id="<?php echo esc_attr( $field_key ); ?>"

--- a/includes/admin/class-wc-accommodation-booking-admin-product-settings.php
+++ b/includes/admin/class-wc-accommodation-booking-admin-product-settings.php
@@ -218,7 +218,7 @@ class WC_Accommodation_Booking_Admin_Product_Settings extends WC_Settings_API {
 			<th scope="row" class="titledesc">
 				<label for="<?php echo esc_attr( $field_key ); ?>"><?php echo esc_html( $value['title'] ); ?></label>
 			</th>
-			<td class="forminp forminp-<?php echo esc_attr( sanitize_title( $value['type'] ) ) ?>">
+			<td class="wc-bookings-render-wp-time-picker forminp forminp-<?php echo esc_attr( sanitize_title( $value['type'] ) ) ?>">
 				<input
 					name="<?php echo esc_attr( $field_key ); ?>"
 					id="<?php echo esc_attr( $field_key ); ?>"


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] ~~Have you written new tests for your changes, as applicable?~~ Not applicable
* [ ] Have you successfully run tests with your changes locally?
* [ ] ~~Will this change require new documentation or changes to existing documentation?~~ Documentation for this change would live on the WooCommerce Bookings side if needed

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

- Add the `wc-bookings-render-wp-time-picker` class to the time input on the Bookings -> Settings -> Accommodations admin menu to render a uniform time selector that follows sitewide time formats
- Update documentation regarding local setup

Closes #364.

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

> [!WARNING]
> **‼️‼️ NOTE - BLOCKED by [WC BOOKINGS PR 3926](https://github.com/woocommerce/woocommerce-bookings/pull/3926): This change relies on code introduced in https://github.com/woocommerce/woocommerce-bookings/pull/3926.

> [!NOTE]
> **There is no chance of introducing bugs if this PR is merged first.**
> Without the WooCommerce Bookings PR there will be no change whatsoever in appearance or functionality of the input time selector. The only code change in this PR is adding the class that the JS uses to select and initialize the time picker.**

1. Access the WordPress admin panel.
1. Navigate to the "General" settings under "Settings" in the WordPress dashboard.
1. In the "Time format" section, select the 24-hour time format (e.g., "20:00" for 8:00 PM).
1. Save the changes.

![image](https://github.com/user-attachments/assets/22166cb4-54e0-4e93-8afb-a72a3b04105c)

5. Navigate to the Accommodation Booking Setting within the plugin `/wp-admin/edit.php?post_type=wc_booking&page=wc_bookings_settings&tab=accommodation`
6. You should see a time selector that adapts to the 24-hour time format
7. Change the time format back to the 12 hour AM/PM configuration. The time selector on `/wp-admin/edit.php?post_type=wc_booking&page=wc_bookings_settings&tab=accommodation` should adapt to display the 12 hour format

![Screenshot 2025-01-22 at 12 03 07 AM](https://github.com/user-attachments/assets/4ebba376-a8f5-45ee-8423-0da1fad2f62e)

#### Functionality - Admin
1. Save a setting and refresh the page. The setting should persist.
2. Perform with both 12 and 24 hour configuration.

#### Functionality - FE
1. Set the check in and check out to a value (and remember the value) - `/wp-admin/edit.php?post_type=wc_booking&page=wc_bookings_settings&tab=accommodation`
2. Create an Accommodation Product

![Screenshot 2025-01-22 at 12 10 16 AM](https://github.com/user-attachments/assets/7de01dc2-2abf-413e-90ea-297c6f635bc1)

3. Navigate to the FE. You should set that the check in and check out time are the same as the value you saved.

![Screenshot 2025-01-22 at 12 11 24 AM](https://github.com/user-attachments/assets/07f8e44a-bbf0-4135-a63e-464a61d7bb3a)

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Update - Render uniform WP time picker over default time input element.
