### PR TITLE
Compatibility testing with Woo 9.7 Beta

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === WooCommerce Accommodation Bookings ===
 Contributors:  woocommerce, automattic
 Tags: woocommerce, bookings, accommodations
-Requires at least: 6.5
+Requires at least: 6.6
 Tested up to: 6.7
 Stable tag: 1.3.1
 License: GNU General Public License v3.0

--- a/tests/e2e/specs/order.spec.js
+++ b/tests/e2e/specs/order.spec.js
@@ -147,6 +147,10 @@ test.describe('Order Tests', () => {
 		// Place order and verify booking details in confirmation email.
 		await page.goto('/checkout');
 		await fillBillingDetails(page, customer.billing, true);
+		await page
+			.locator('label.wc-block-components-radio-control__option')
+			.first()
+			.waitFor();
 		const orderId = await placeOrder(page, true);
 		await api.update.order({
 			id: orderId,

--- a/tests/e2e/specs/product.spec.js
+++ b/tests/e2e/specs/product.spec.js
@@ -281,6 +281,10 @@ test.describe('Product Tests', () => {
 		// Place order
 		await page.goto('/checkout');
 		await fillBillingDetails(page, customer.billing, true);
+		await page
+			.locator('label.wc-block-components-radio-control__option')
+			.first()
+			.waitFor();
 		const orderId = await placeOrder(page, true);
 
 		page.goto('/my-account/bookings/');

--- a/woocommerce-accommodation-bookings.php
+++ b/woocommerce-accommodation-bookings.php
@@ -10,9 +10,9 @@
  * Text Domain: woocommerce-accommodation-bookings
  * Domain Path: /languages
  * Tested up to: 6.7
- * Requires at least: 6.5
- * WC tested up to: 9.6
- * WC requires at least: 9.4
+ * Requires at least: 6.6
+ * WC tested up to: 9.7
+ * WC requires at least: 9.5
  * PHP tested up to: 8.3
  * Requires PHP: 7.4
  *


### PR DESCRIPTION
### All Submissions:

* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---
### Changes proposed in this Pull Request:

- Bump WooCommerce "tested up to" version 9.7
- Bump WooCommerce minimum supported version to 9.5
- Bump WordPress minimum supported version to 6.6.



Closes #490

### Steps to test the changes in this Pull Request:

1. Run the e2e test using GitHub action to test this PR 
2. All tests should be passed. 

### Changelog entry

> Dev - Bump WooCommerce "tested up to" version 9.7.
> Dev - Bump WooCommerce minimum supported version to 9.5.
> Dev - Bump WordPress minimum supported version to 6.6.





