### PR TITLE
Compatibility testing with WordPress 6.8 

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:  woocommerce, automattic
 Tags: woocommerce, bookings, accommodations
 Requires at least: 6.6
-Tested up to: 6.7
+Tested up to: 6.8
 Stable tag: 1.3.2
 License: GNU General Public License v3.0
 License URI: http://www.gnu.org/licenses/gpl-3.0.html

--- a/woocommerce-accommodation-bookings.php
+++ b/woocommerce-accommodation-bookings.php
@@ -9,7 +9,7 @@
  * Author URI: https://woocommerce.com
  * Text Domain: woocommerce-accommodation-bookings
  * Domain Path: /languages
- * Tested up to: 6.7
+ * Tested up to: 6.8
  * Requires at least: 6.6
  * WC tested up to: 9.8
  * WC requires at least: 9.6


### PR DESCRIPTION
### All Submissions:

* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

 - Bump WordPress "tested up to" version 6.8.




Closes https://github.com/woocommerce/woocommerce-accommodation-bookings/issues/499


### Steps to test the changes in this Pull Request:

1. Run the e2e test using GitHub action to test this PR.
2. All tests should be passed. 
 

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Dev - Bump WordPress "tested up to" version 6.8.



