### PR TITLE
Remove unused library from eslintrc.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,7 +18,6 @@ module.exports = {
 		//`import/no-unresolved` rules account for them.
 		'import/core-modules': [
 			'@woocommerce/blocks-registry',
-			'@woocommerce/settings',
 			'@wordpress/i18n',
 			'@wordpress/element',
 			'@wordpress/html-entities',


### PR DESCRIPTION
> [!Caution]
>
> # **DO NOT MERGE**
>
> Re-evaluating this per the [comment below](https://github.com/woocommerce/woocommerce-accommodation-bookings/pull/513#issuecomment-3006571511).

### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

Remove deprecated WooCommerce Packages.

* No deprecated packages in use
* Remove reference to deprecated package in eslint config files

Closes WOOACBK-43

### Steps to test the changes in this Pull Request:

1. Run `nvm use`
2. Run `npm ci`
3. Run `npm run build`
4. Ensure the build complete successfully
5. Create the file in the root directory `.wp-env.override.json` with the contents:
   ```
   {
     "plugins": [
       "https://downloads.wordpress.org/plugin/woocommerce.zip",
       "https://downloads.wordpress.org/plugin/email-log.zip",
   	"../woocommerce-bookings/"
     ],
     "themes": [
       "https://downloads.wordpress.org/theme/storefront.zip"
     ],
     "env": {
       "tests": {
         "mappings": {
           "wp-cli.yml": "./tests/e2e/bin/wp-cli.yml",
           "wp-content/plugins/woocommerce-accommodation-bookings": "."
         }
       }
     }
   }
   ```
6. Ensure you have woocommerce-bookings checked out and built in the plugins directory of your install
7. Run `npm run env:start`
8. Run `npm run tests:e2e-local`
9. Ensure the tests pass

> [!Note]
>
> I attempted to run the E2E tests on this branch but it seems that the woocommerce-bookings is not available to the API token stored in the secrets for this repository.

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

I don't think this needs a changelog as the reference in the eslint config file was not used.