### PR TITLE
Add get_time_interval_in_minutes

### DIFF
--- a/includes/class-wc-product-accommodation-booking.php
+++ b/includes/class-wc-product-accommodation-booking.php
@@ -410,6 +410,17 @@ if ( ! class_exists( 'WC_Product_Accommodation_Booking' ) && class_exists( 'WC_P
 		public function get_duration( $context = 'view' ) {
 			return 1;
 		}
+
+		/**
+		 * Get the duration time interval in minutes.
+		 *
+		 * Duration unit is always one night.
+		 *
+		 * @return int duration in minutes.
+		 */
+		public function get_time_interval_in_minutes() {
+			return 1440; // 60 minutes * 24 hours
+		}
 	}
 
 endif;

--- a/includes/class-wc-product-accommodation-booking.php
+++ b/includes/class-wc-product-accommodation-booking.php
@@ -419,7 +419,7 @@ if ( ! class_exists( 'WC_Product_Accommodation_Booking' ) && class_exists( 'WC_P
 		 * @return int duration in minutes.
 		 */
 		public function get_time_interval_in_minutes() {
-			return 1440; // 60 minutes * 24 hours
+			return DAY_IN_SECONDS / MINUTE_IN_SECONDS;
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [X] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Overide the get_time_interval_in_minutes function because the original one always returned 1 minute with the unit of night
This was breaking the callender intersection detection

Closes https://linear.app/a8c/issue/WOOACBK-58/tracking-issue-add-get-time-interval-in-minutes

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

1. Have a product with restricted booking days for only one day
2. Book it for one week
3. Try to book the next week

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Add - Overide the get_time_interval_in_minutes function for WC_Product_Accommodation_Booking
