### PR TITLE
Fix jQuery import.

### DIFF
--- a/src/js/writepanel.js
+++ b/src/js/writepanel.js
@@ -1,4 +1,4 @@
-import { jQuery } from 'jquery';
+import jQuery from 'jquery';
 
 jQuery(function ($) {
 	$('#rates_rows').sortable({


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

Fixes an incorrect import of jQuery introduced in https://github.com/woocommerce/woocommerce-accommodation-bookings/commit/897c48ea329390d3321eeccbf475851406454338.

Closes https://linear.app/a8c/issue/WOOACBK-65/typeerror-jquery-error-when-creating-a-product

### Steps to test the changes in this Pull Request:

1. Activate Bookings and Bookings Availability
2. Navigate to the New Product screen
3. On trunk you will see `writepanel.js` throw a console error that jQuery is not defined -- the full error should be that `Uncaught TypeError: jquery__WEBPACK_IMPORTED_MODULE_0__.jQuery is not a function` in Firefox, similar in other browsers.
4. On this branch, no such error should occur


### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Fix - JavasScript error reference to jQuery on New Product page.
