### PR TITLE
Compatibility testing with WordPress 6.9

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:  woocommerce, automattic
 Tags: woocommerce, bookings, accommodations
 Requires at least: 6.7
-Tested up to: 6.8
+Tested up to: 6.9
 Stable tag: 1.3.5
 License: GNU General Public License v3.0
 License URI: http://www.gnu.org/licenses/gpl-3.0.html

--- a/tests/e2e/specs/order.spec.js
+++ b/tests/e2e/specs/order.spec.js
@@ -166,6 +166,7 @@ test.describe('Order Tests', () => {
 		await confirmBooking(adminPage, bookingId);
 
 		await adminPage.goto('/wp-admin/admin.php?page=email-log');
+		await adminPage.goto('/wp-admin/admin.php?page=email-log');
 		const emailRow = await adminPage
 			.locator('#the-list tr', {
 				hasText: ` has been confirmed (Order ${orderId}) -`,

--- a/tests/e2e/utils/index.js
+++ b/tests/e2e/utils/index.js
@@ -654,6 +654,7 @@ export async function confirmBooking(page, bookingId) {
  */
 export async function clearEmailLogs(page) {
 	await page.goto('/wp-admin/admin.php?page=email-log');
+	await page.goto('/wp-admin/admin.php?page=email-log');
 	const bulkAction = await page.locator('#bulk-action-selector-top');
 	if (await bulkAction.isVisible()) {
 		await page.locator('#cb-select-all-1').click();

--- a/woocommerce-accommodation-bookings.php
+++ b/woocommerce-accommodation-bookings.php
@@ -9,7 +9,7 @@
  * Author URI: https://woocommerce.com
  * Text Domain: woocommerce-accommodation-bookings
  * Domain Path: /languages
- * Tested up to: 6.8
+ * Tested up to: 6.9
  * Requires at least: 6.7
  * WC tested up to: 10.3
  * WC requires at least: 10.1


### PR DESCRIPTION
### All Submissions:

* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

 - Bump WordPress "tested up to" version 6.9




Closes https://linear.app/a8c/issue/WOOACBK-68/compatibility-testing-with-wordpress-69-rc1


### Steps to test the changes in this Pull Request:

1. Run the e2e test using GitHub action to test this PR.
2. All tests should be passed. 
 

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Dev - Bump WordPress "tested up to" version 6.9.