### PR TITLE
Handle the Booked Blocks structure to display correct availability

### DIFF
--- a/includes/admin/class-wc-accommodation-booking-rest-and-admin.php
+++ b/includes/admin/class-wc-accommodation-booking-rest-and-admin.php
@@ -21,6 +21,9 @@ class WC_Accommodation_Booking_REST_And_Admin {
 		add_filter( 'product_type_selector', array( $this, 'product_type_selector' ) );
 
 		add_action( 'woocommerce_process_product_meta', array( $this, 'save_product_data' ), 25 );
+
+		// Add debug tool for clearing stale booking transients.
+		add_filter( 'woocommerce_debug_tools', array( $this, 'accommodation_bookings_debug_tools' ) );
 	}
 
 	/**
@@ -341,6 +344,45 @@ class WC_Accommodation_Booking_REST_And_Admin {
 			),
 			'%d'
 		);
+	}
+
+	/**
+	 * Accommodation Bookings debug tools in WooCommerce > Status > Tools.
+	 *
+	 * @param array $tools Existing tools.
+	 * @return array Tools with Accommodation Bookings tools added.
+	 */
+	public function accommodation_bookings_debug_tools( $tools ) {
+		$accommodation_tools = array(
+			'clear_stale_booking_transients' => array(
+				'name'     => __( 'Clear stale booking transients', 'woocommerce-accommodation-bookings' ),
+				'button'   => __( 'Clear transients', 'woocommerce-accommodation-bookings' ),
+				'desc'     => __( 'This tool will clear stale booking transients that may cause issues after upgrading to WooCommerce Bookings 3.0+.', 'woocommerce-accommodation-bookings' ),
+				'callback' => array( $this, 'clear_stale_booking_transients_tool' ),
+			),
+		);
+
+		return array_merge( $tools, $accommodation_tools );
+	}
+
+	/**
+	 * Callback for clearing stale booking transients tool.
+	 *
+	 * @return string Success message.
+	 */
+	public function clear_stale_booking_transients_tool() {
+		if ( ! class_exists( 'WC_Product_Accommodation_Booking' ) ) {
+			return __( 'Error: Accommodation Bookings class not found.', 'woocommerce-accommodation-bookings' );
+		}
+
+		if ( ! method_exists( 'WC_Product_Accommodation_Booking', 'maybe_clear_stale_transients' ) ) {
+			return __( 'Error: Method not found. Please ensure you are using the latest version of Accommodation Bookings.', 'woocommerce-accommodation-bookings' );
+		}
+
+		// Call the method to clear transients.
+		WC_Product_Accommodation_Booking::maybe_clear_stale_transients();
+
+		return __( 'Stale booking transients cleared successfully.', 'woocommerce-accommodation-bookings' );
 	}
 }
 

--- a/includes/admin/class-wc-accommodation-booking-rest-and-admin.php
+++ b/includes/admin/class-wc-accommodation-booking-rest-and-admin.php
@@ -371,18 +371,52 @@ class WC_Accommodation_Booking_REST_And_Admin {
 	 * @return string Success message.
 	 */
 	public function clear_stale_booking_transients_tool() {
-		if ( ! class_exists( 'WC_Product_Accommodation_Booking' ) ) {
-			return __( 'Error: Accommodation Bookings class not found.', 'woocommerce-accommodation-bookings' );
-		}
-
-		if ( ! method_exists( 'WC_Product_Accommodation_Booking', 'maybe_clear_stale_transients' ) ) {
-			return __( 'Error: Method not found. Please ensure you are using the latest version of Accommodation Bookings.', 'woocommerce-accommodation-bookings' );
+		// Check user capabilities.
+		if ( ! current_user_can( 'manage_woocommerce' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown
+			return __( 'Error: You do not have permission to run this tool.', 'woocommerce-accommodation-bookings' );
 		}
 
 		// Call the method to clear transients.
-		WC_Product_Accommodation_Booking::maybe_clear_stale_transients();
+		$this->clear_stale_booking_transients();
 
 		return __( 'Stale booking transients cleared successfully.', 'woocommerce-accommodation-bookings' );
+	}
+
+	/**
+	 * Clear stale booking transients that may cause availability or booking issues.
+	 * Can be run multiple times safely.
+	 *
+	 * @return void
+	 */
+	private function clear_stale_booking_transients() {
+		// Step 1: Use parent plugin's method first (clears tracked transients and updates tracking array).
+		if ( class_exists( 'WC_Bookings_Cache' ) && method_exists( 'WC_Bookings_Cache', 'delete_booking_slots_transient' ) ) {
+			WC_Bookings_Cache::delete_booking_slots_transient(); // No product ID = clears all tracked transients.
+		}
+
+		// Step 2: Clear any orphaned transients directly (safety net for transients not in tracking array).
+		// This catches transients that got out of sync.
+		global $wpdb;
+
+		if ( ! $wpdb || ! isset( $wpdb->options ) ) {
+			return; // Database not available.
+		}
+
+		// Delete timeout entries.
+		$wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM {$wpdb->options} WHERE option_name LIKE %s",
+				$wpdb->esc_like( '_transient_timeout_book_ts_' ) . '%'
+			)
+		);
+
+		// Delete transient entries.
+		$wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM {$wpdb->options} WHERE option_name LIKE %s",
+				$wpdb->esc_like( '_transient_book_ts_' ) . '%'
+			)
+		);
 	}
 }
 

--- a/includes/admin/class-wc-accommodation-booking-rest-and-admin.php
+++ b/includes/admin/class-wc-accommodation-booking-rest-and-admin.php
@@ -357,7 +357,7 @@ class WC_Accommodation_Booking_REST_And_Admin {
 			'clear_stale_booking_transients' => array(
 				'name'     => __( 'Clear stale booking transients', 'woocommerce-accommodation-bookings' ),
 				'button'   => __( 'Clear transients', 'woocommerce-accommodation-bookings' ),
-				'desc'     => __( 'This tool will clear stale booking transients that may cause issues after upgrading to WooCommerce Bookings 3.0+.', 'woocommerce-accommodation-bookings' ),
+				'desc'     => __( 'This tool will clear stale booking transients that may cause availability or booking issues.', 'woocommerce-accommodation-bookings' ),
 				'callback' => array( $this, 'clear_stale_booking_transients_tool' ),
 			),
 		);

--- a/includes/class-wc-accommodation-bookings-plugin.php
+++ b/includes/class-wc-accommodation-bookings-plugin.php
@@ -130,6 +130,11 @@ class WC_Accommodation_Bookings_Plugin {
 		if ( is_admin() ) {
 			add_action( 'init', array( $this, 'admin_includes' ), 10 );
 			add_action( 'woocommerce_product_duplicate', array( $this, 'woocommerce_duplicate_product' ), 10, 2 );
+			// Hook cache clearing method for WC Bookings v3+ compatibility.
+			// This is a temporary fix to handle the issue with the stale transients.
+			// This can be removed in future once the minimum version of WC Bookings is 3.0.0 or higher.
+			// See https://github.com/woocommerce/woocommerce-accommodation-bookings/issues/563.
+			add_action( 'admin_init', array( 'WC_Product_Accommodation_Booking', 'maybe_clear_stale_transients' ), 1 );
 		}
 
 		add_action( 'shutdown', array( $this, 'install' ) );

--- a/includes/class-wc-accommodation-bookings-plugin.php
+++ b/includes/class-wc-accommodation-bookings-plugin.php
@@ -130,11 +130,6 @@ class WC_Accommodation_Bookings_Plugin {
 		if ( is_admin() ) {
 			add_action( 'init', array( $this, 'admin_includes' ), 10 );
 			add_action( 'woocommerce_product_duplicate', array( $this, 'woocommerce_duplicate_product' ), 10, 2 );
-			// Hook cache clearing method for WC Bookings v3+ compatibility.
-			// This is a temporary fix to handle the issue with the stale transients.
-			// This can be removed in future once the minimum version of WC Bookings is 3.0.0 or higher.
-			// See https://github.com/woocommerce/woocommerce-accommodation-bookings/issues/563.
-			add_action( 'admin_init', array( 'WC_Product_Accommodation_Booking', 'maybe_clear_stale_transients' ), 1 );
 		}
 
 		add_action( 'shutdown', array( $this, 'install' ) );

--- a/includes/class-wc-product-accommodation-booking.php
+++ b/includes/class-wc-product-accommodation-booking.php
@@ -13,7 +13,7 @@ if ( ! class_exists( 'WC_Product_Accommodation_Booking' ) && class_exists( 'WC_P
 
 		/**
 		 * Minimum timestamp value for detecting v2 format timestamps.
-		 * Timestamps below this (Jan 1, 2001) are considered invalid for booking detection.
+		 * Timestamps below this (2001) are considered invalid for booking detection.
 		 *
 		 * @var int
 		 */

--- a/includes/class-wc-product-accommodation-booking.php
+++ b/includes/class-wc-product-accommodation-booking.php
@@ -61,16 +61,6 @@ if ( ! class_exists( 'WC_Product_Accommodation_Booking' ) && class_exists( 'WC_P
 			$this->wc_booking_duration_type = 'customer';
 			$this->wc_booking_duration_unit = 'night';
 			$this->wc_booking_duration      = 1;
-
-			// Hook cache clearing method (only adds once).
-			// This is a temporary fix to handle the issue with the stale transients.
-			// This can be removed in future once the minimum version of WC Bookings is 3.0.0 or higher.
-			// See https://github.com/woocommerce/woocommerce-accommodation-bookings/issues/563.
-			static $hook_added = false;
-			if ( ! $hook_added ) {
-				add_action( 'admin_init', array( __CLASS__, 'maybe_clear_stale_transients' ), 1 );
-				$hook_added = true;
-			}
 		}
 
 

--- a/includes/class-wc-product-accommodation-booking.php
+++ b/includes/class-wc-product-accommodation-booking.php
@@ -57,7 +57,7 @@ if ( ! class_exists( 'WC_Product_Accommodation_Booking' ) && class_exists( 'WC_P
 			// Hook cache clearing method (only adds once).
 			// This is a temporary fix to handle the issue with the stale transients.
 			// This can be in removed in future once the minimum version of WC Bookings is 3.0.0 or higher.
-			// See https://github.com/woocommerce/woocommerce-accommodation-bookings/issues/563
+			// See https://github.com/woocommerce/woocommerce-accommodation-bookings/issues/563.
 			static $hook_added = false;
 			if ( ! $hook_added ) {
 				add_action( 'admin_init', array( __CLASS__, 'maybe_clear_stale_transients' ), 1 );
@@ -377,7 +377,7 @@ if ( ! class_exists( 'WC_Product_Accommodation_Booking' ) && class_exists( 'WC_P
 			// array_unique() destroys this structure by re-indexing with numeric keys and removing duplicate values.
 			// Only apply array_unique() for older versions that returned flat arrays.
 			// This normalize method and the array_unique() can be removed in future once the minimum version of WC Bookings is 3.0.0 or higher.
-			// See https://github.com/woocommerce/woocommerce-accommodation-bookings/issues/563
+			// See https://github.com/woocommerce/woocommerce-accommodation-bookings/issues/563.
 			if ( defined( 'WC_BOOKINGS_VERSION' ) && version_compare( WC_BOOKINGS_VERSION, '3.0.0', '>=' ) ) {
 				// Normalize format to handle both v2 (flat) and v3 (associative) formats gracefully.
 				return $this->normalize_blocks_array( $blocks_in_range );
@@ -406,7 +406,7 @@ if ( ! class_exists( 'WC_Product_Accommodation_Booking' ) && class_exists( 'WC_P
 
 			// Detect v2 format: keys are sequential array indices starting from 0, values are timestamps (large integers).
 			// v3 format: keys are timestamps (large integers), values are booked counts (small integers).
-			if ( is_numeric( $first_key ) && $first_key === 0 
+			if ( is_numeric( $first_key ) && $first_key === 0
 				&& is_numeric( $first_value ) && $first_value > 1000000000 ) {
 				// Convert v2 flat array to v3 associative format.
 				// All dates from v2 are treated as available (booked_count = 0).
@@ -498,18 +498,22 @@ if ( ! class_exists( 'WC_Product_Accommodation_Booking' ) && class_exists( 'WC_P
 			// Step 2: Clear any orphaned transients directly (safety net for transients not in tracking array).
 			// This catches transients that got out of sync.
 			global $wpdb;
-			
+
 			// Delete timeout entries.
-			$wpdb->query( $wpdb->prepare( 
-				"DELETE FROM {$wpdb->options} WHERE option_name LIKE %s", 
-				$wpdb->esc_like( '_transient_timeout_book_ts_' ) . '%'
-			) );
+			$wpdb->query(
+				$wpdb->prepare(
+					"DELETE FROM {$wpdb->options} WHERE option_name LIKE %s",
+					$wpdb->esc_like( '_transient_timeout_book_ts_' ) . '%'
+				)
+			);
 
 			// Delete transient entries.
-			$wpdb->query( $wpdb->prepare( 
-				"DELETE FROM {$wpdb->options} WHERE option_name LIKE %s", 
-				$wpdb->esc_like( '_transient_book_ts_' ) . '%'
-			) );
+			$wpdb->query(
+				$wpdb->prepare(
+					"DELETE FROM {$wpdb->options} WHERE option_name LIKE %s",
+					$wpdb->esc_like( '_transient_book_ts_' ) . '%'
+				)
+			);
 		}
 	}
 

--- a/includes/class-wc-product-accommodation-booking.php
+++ b/includes/class-wc-product-accommodation-booking.php
@@ -484,7 +484,7 @@ if ( ! class_exists( 'WC_Product_Accommodation_Booking' ) && class_exists( 'WC_P
 		 */
 		public static function maybe_clear_stale_transients() {
 			// Only run if user has proper capabilities.
-			if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			if ( ! current_user_can( 'manage_woocommerce' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown
 				return;
 			}
 

--- a/includes/class-wc-product-accommodation-booking.php
+++ b/includes/class-wc-product-accommodation-booking.php
@@ -467,8 +467,9 @@ if ( ! class_exists( 'WC_Product_Accommodation_Booking' ) && class_exists( 'WC_P
 		}
 
 		/**
-		 * Clear stale booking transients automatically when WC Bookings v3+ is detected.
-		 * Runs once on admin_init, then never again.
+		 * Clear stale booking transients that may cause availability or booking issues.
+		 * Called manually via WooCommerce Status Tools.
+		 * Can be run multiple times safely.
 		 *
 		 * @return void
 		 */
@@ -477,20 +478,6 @@ if ( ! class_exists( 'WC_Product_Accommodation_Booking' ) && class_exists( 'WC_P
 			if ( ! current_user_can( 'manage_woocommerce' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown
 				return;
 			}
-
-			// Only run if WC Bookings v3+ is active.
-			if ( ! defined( 'WC_BOOKINGS_VERSION' ) || version_compare( WC_BOOKINGS_VERSION, '3.0.0', '<' ) ) {
-				return;
-			}
-
-			// Check if we've already cleared transients (once is enough).
-			$option_key = 'woocommerce_accommodation_bookings_v3_transients_cleared';
-			if ( get_option( $option_key ) ) {
-				return; // Already cleared - zero overhead.
-			}
-
-			// Mark as cleared immediately to prevent duplicate runs.
-			update_option( $option_key, true );
 
 			// Step 1: Use parent plugin's method first (clears tracked transients and updates tracking array).
 			if ( class_exists( 'WC_Bookings_Cache' ) && method_exists( 'WC_Bookings_Cache', 'delete_booking_slots_transient' ) ) {

--- a/includes/class-wc-product-accommodation-booking.php
+++ b/includes/class-wc-product-accommodation-booking.php
@@ -466,48 +466,6 @@ if ( ! class_exists( 'WC_Product_Accommodation_Booking' ) && class_exists( 'WC_P
 			return 1;
 		}
 
-		/**
-		 * Clear stale booking transients that may cause availability or booking issues.
-		 * Called manually via WooCommerce Status Tools.
-		 * Can be run multiple times safely.
-		 *
-		 * @return void
-		 */
-		public static function maybe_clear_stale_transients() {
-			// Only run if user has proper capabilities.
-			if ( ! current_user_can( 'manage_woocommerce' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown
-				return;
-			}
-
-			// Step 1: Use parent plugin's method first (clears tracked transients and updates tracking array).
-			if ( class_exists( 'WC_Bookings_Cache' ) && method_exists( 'WC_Bookings_Cache', 'delete_booking_slots_transient' ) ) {
-				WC_Bookings_Cache::delete_booking_slots_transient(); // No product ID = clears all tracked transients.
-			}
-
-			// Step 2: Clear any orphaned transients directly (safety net for transients not in tracking array).
-			// This catches transients that got out of sync.
-			global $wpdb;
-
-			if ( ! $wpdb || ! isset( $wpdb->options ) ) {
-				return; // Database not available.
-			}
-
-			// Delete timeout entries.
-			$wpdb->query(
-				$wpdb->prepare(
-					"DELETE FROM {$wpdb->options} WHERE option_name LIKE %s",
-					$wpdb->esc_like( '_transient_timeout_book_ts_' ) . '%'
-				)
-			);
-
-			// Delete transient entries.
-			$wpdb->query(
-				$wpdb->prepare(
-					"DELETE FROM {$wpdb->options} WHERE option_name LIKE %s",
-					$wpdb->esc_like( '_transient_book_ts_' ) . '%'
-				)
-			);
-		}
 	}
 
 endif;

--- a/includes/class-wc-product-accommodation-booking.php
+++ b/includes/class-wc-product-accommodation-booking.php
@@ -363,6 +363,13 @@ if ( ! class_exists( 'WC_Product_Accommodation_Booking' ) && class_exists( 'WC_P
 
 			$blocks_in_range = $this->get_blocks_in_range_for_day( $start_date, $end_date, $resource_id, $booked );
 
+			// WC Bookings 3.0.0+ returns an associative array [timestamp => booked_count].
+			// array_unique() destroys this structure by re-indexing with numeric keys.
+			// Only apply array_unique() for older versions that returned flat arrays.
+			if ( defined( 'WC_BOOKINGS_VERSION' ) && version_compare( WC_BOOKINGS_VERSION, '3.0.0', '>=' ) ) {
+				return $blocks_in_range;
+			}
+
 			return array_unique( $blocks_in_range );
 		}
 

--- a/includes/class-wc-product-accommodation-booking.php
+++ b/includes/class-wc-product-accommodation-booking.php
@@ -53,6 +53,16 @@ if ( ! class_exists( 'WC_Product_Accommodation_Booking' ) && class_exists( 'WC_P
 			$this->wc_booking_duration_type = 'customer';
 			$this->wc_booking_duration_unit = 'night';
 			$this->wc_booking_duration      = 1;
+
+			// Hook cache clearing method (only adds once).
+			// This is a temporary fix to handle the issue with the stale transients.
+			// This can be in removed in future once the minimum version of WC Bookings is 3.0.0 or higher.
+			// See https://github.com/woocommerce/woocommerce-accommodation-bookings/issues/563
+			static $hook_added = false;
+			if ( ! $hook_added ) {
+				add_action( 'admin_init', array( __CLASS__, 'maybe_clear_stale_transients' ), 1 );
+				$hook_added = true;
+			}
 		}
 
 
@@ -364,13 +374,53 @@ if ( ! class_exists( 'WC_Product_Accommodation_Booking' ) && class_exists( 'WC_P
 			$blocks_in_range = $this->get_blocks_in_range_for_day( $start_date, $end_date, $resource_id, $booked );
 
 			// WC Bookings 3.0.0+ returns an associative array [timestamp => booked_count].
-			// array_unique() destroys this structure by re-indexing with numeric keys.
+			// array_unique() destroys this structure by re-indexing with numeric keys and removing duplicate values.
 			// Only apply array_unique() for older versions that returned flat arrays.
+			// This normalize method and the array_unique() can be removed in future once the minimum version of WC Bookings is 3.0.0 or higher.
+			// See https://github.com/woocommerce/woocommerce-accommodation-bookings/issues/563
 			if ( defined( 'WC_BOOKINGS_VERSION' ) && version_compare( WC_BOOKINGS_VERSION, '3.0.0', '>=' ) ) {
-				return $blocks_in_range;
+				// Normalize format to handle both v2 (flat) and v3 (associative) formats gracefully.
+				return $this->normalize_blocks_array( $blocks_in_range );
 			}
 
+			// For v2.x and earlier, apply array_unique() to remove duplicate timestamps from flat array.
 			return array_unique( $blocks_in_range );
+		}
+
+		/**
+		 * Normalize blocks array to handle both v2 (flat) and v3 (associative) formats.
+		 * Automatically converts stale v2-format data from cached transients to v3 format.
+		 *
+		 * @param array $blocks Array of blocks (may be flat array from v2 or associative from v3).
+		 * @return array Normalized associative array compatible with v3 format.
+		 */
+		private function normalize_blocks_array( $blocks ) {
+			if ( empty( $blocks ) ) {
+				return array();
+			}
+
+			// Check if this is a v2-format flat array (numeric keys, all values are timestamps).
+			// v3 format has associative keys (timestamps) with booked counts as values.
+			$first_key   = array_key_first( $blocks );
+			$first_value = reset( $blocks );
+
+			// Detect v2 format: keys are sequential array indices starting from 0, values are timestamps (large integers).
+			// v3 format: keys are timestamps (large integers), values are booked counts (small integers).
+			if ( is_numeric( $first_key ) && $first_key === 0 
+				&& is_numeric( $first_value ) && $first_value > 1000000000 ) {
+				// Convert v2 flat array to v3 associative format.
+				// All dates from v2 are treated as available (booked_count = 0).
+				$normalized = array();
+				foreach ( $blocks as $timestamp ) {
+					if ( is_numeric( $timestamp ) && $timestamp > 1000000000 ) {
+						$normalized[ (int) $timestamp ] = 0;
+					}
+				}
+				return $normalized;
+			}
+
+			// Already in v3 format, return as-is.
+			return $blocks;
 		}
 
 		/**
@@ -416,6 +466,50 @@ if ( ! class_exists( 'WC_Product_Accommodation_Booking' ) && class_exists( 'WC_P
 		 */
 		public function get_duration( $context = 'view' ) {
 			return 1;
+		}
+
+		/**
+		 * Clear stale booking transients automatically when WC Bookings v3+ is detected.
+		 * Runs once on admin_init, then never again.
+		 * Uses batched deletion to avoid performance impact.
+		 *
+		 * @return void
+		 */
+		public static function maybe_clear_stale_transients() {
+			// Only run if WC Bookings v3+ is active.
+			if ( ! defined( 'WC_BOOKINGS_VERSION' ) || version_compare( WC_BOOKINGS_VERSION, '3.0.0', '<' ) ) {
+				return;
+			}
+
+			// Check if we've already cleared transients (once is enough).
+			$option_key = 'woocommerce_accommodation_bookings_v3_transients_cleared';
+			if ( get_option( $option_key ) ) {
+				return; // Already cleared - zero overhead.
+			}
+
+			// Mark as cleared immediately to prevent duplicate runs.
+			update_option( $option_key, true );
+
+			// Step 1: Use parent plugin's method first (clears tracked transients and updates tracking array).
+			if ( class_exists( 'WC_Bookings_Cache' ) && method_exists( 'WC_Bookings_Cache', 'delete_booking_slots_transient' ) ) {
+				WC_Bookings_Cache::delete_booking_slots_transient(); // No product ID = clears all tracked transients.
+			}
+
+			// Step 2: Clear any orphaned transients directly (safety net for transients not in tracking array).
+			// This catches transients that got out of sync.
+			global $wpdb;
+			
+			// Delete timeout entries.
+			$wpdb->query( $wpdb->prepare( 
+				"DELETE FROM {$wpdb->options} WHERE option_name LIKE %s", 
+				$wpdb->esc_like( '_transient_timeout_book_ts_' ) . '%'
+			) );
+
+			// Delete transient entries.
+			$wpdb->query( $wpdb->prepare( 
+				"DELETE FROM {$wpdb->options} WHERE option_name LIKE %s", 
+				$wpdb->esc_like( '_transient_book_ts_' ) . '%'
+			) );
 		}
 	}
 

--- a/includes/class-wc-product-accommodation-booking.php
+++ b/includes/class-wc-product-accommodation-booking.php
@@ -406,7 +406,7 @@ if ( ! class_exists( 'WC_Product_Accommodation_Booking' ) && class_exists( 'WC_P
 
 			// Detect v2 format: keys are sequential array indices starting from 0, values are timestamps (large integers).
 			// v3 format: keys are timestamps (large integers), values are booked counts (small integers).
-			if ( is_numeric( $first_key ) && $first_key === 0
+			if ( is_numeric( $first_key ) && 0 === $first_key
 				&& is_numeric( $first_value ) && $first_value > 1000000000 ) {
 				// Convert v2 flat array to v3 associative format.
 				// All dates from v2 are treated as available (booked_count = 0).

--- a/includes/class-wc-product-accommodation-booking.php
+++ b/includes/class-wc-product-accommodation-booking.php
@@ -465,7 +465,6 @@ if ( ! class_exists( 'WC_Product_Accommodation_Booking' ) && class_exists( 'WC_P
 		public function get_duration( $context = 'view' ) {
 			return 1;
 		}
-
 	}
 
 endif;

--- a/includes/class-wc-product-accommodation-booking.php
+++ b/includes/class-wc-product-accommodation-booking.php
@@ -12,6 +12,14 @@ if ( ! class_exists( 'WC_Product_Accommodation_Booking' ) && class_exists( 'WC_P
 	class WC_Product_Accommodation_Booking extends WC_Product_Booking {
 
 		/**
+		 * Minimum timestamp value for detecting v2 format timestamps.
+		 * Timestamps below this (Jan 1, 2001) are considered invalid for booking detection.
+		 *
+		 * @var int
+		 */
+		const MIN_TIMESTAMP = 1000000000;
+
+		/**
 		 * The type of product we're creating
 		 *
 		 * @var string
@@ -56,7 +64,7 @@ if ( ! class_exists( 'WC_Product_Accommodation_Booking' ) && class_exists( 'WC_P
 
 			// Hook cache clearing method (only adds once).
 			// This is a temporary fix to handle the issue with the stale transients.
-			// This can be in removed in future once the minimum version of WC Bookings is 3.0.0 or higher.
+			// This can be removed in future once the minimum version of WC Bookings is 3.0.0 or higher.
 			// See https://github.com/woocommerce/woocommerce-accommodation-bookings/issues/563.
 			static $hook_added = false;
 			if ( ! $hook_added ) {
@@ -407,12 +415,12 @@ if ( ! class_exists( 'WC_Product_Accommodation_Booking' ) && class_exists( 'WC_P
 			// Detect v2 format: keys are sequential array indices starting from 0, values are timestamps (large integers).
 			// v3 format: keys are timestamps (large integers), values are booked counts (small integers).
 			if ( is_numeric( $first_key ) && 0 === $first_key
-				&& is_numeric( $first_value ) && $first_value > 1000000000 ) {
+				&& is_numeric( $first_value ) && $first_value > self::MIN_TIMESTAMP ) {
 				// Convert v2 flat array to v3 associative format.
 				// All dates from v2 are treated as available (booked_count = 0).
 				$normalized = array();
 				foreach ( $blocks as $timestamp ) {
-					if ( is_numeric( $timestamp ) && $timestamp > 1000000000 ) {
+					if ( is_numeric( $timestamp ) && $timestamp > self::MIN_TIMESTAMP ) {
 						$normalized[ (int) $timestamp ] = 0;
 					}
 				}
@@ -471,11 +479,15 @@ if ( ! class_exists( 'WC_Product_Accommodation_Booking' ) && class_exists( 'WC_P
 		/**
 		 * Clear stale booking transients automatically when WC Bookings v3+ is detected.
 		 * Runs once on admin_init, then never again.
-		 * Uses batched deletion to avoid performance impact.
 		 *
 		 * @return void
 		 */
 		public static function maybe_clear_stale_transients() {
+			// Only run if user has proper capabilities.
+			if ( ! current_user_can( 'manage_woocommerce' ) ) {
+				return;
+			}
+
 			// Only run if WC Bookings v3+ is active.
 			if ( ! defined( 'WC_BOOKINGS_VERSION' ) || version_compare( WC_BOOKINGS_VERSION, '3.0.0', '<' ) ) {
 				return;
@@ -498,6 +510,10 @@ if ( ! class_exists( 'WC_Product_Accommodation_Booking' ) && class_exists( 'WC_P
 			// Step 2: Clear any orphaned transients directly (safety net for transients not in tracking array).
 			// This catches transients that got out of sync.
 			global $wpdb;
+
+			if ( ! $wpdb || ! isset( $wpdb->options ) ) {
+				return; // Database not available.
+			}
 
 			// Delete timeout entries.
 			$wpdb->query(


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

> [!NOTE]
> The cache clearing logic is updated later in this PR. Check https://github.com/woocommerce/woocommerce-accommodation-bookings/pull/564#issuecomment-3784058052 for more details.

From https://github.com/woocommerce/woocommerce-accommodation-bookings/issues/563#issue-3798756722:

> The `get_blocks_in_range()` method override in `WC_Product_Accommodation_Booking` (line 362-367 of `class-wc-product-accommodation-booking.php`) is incompatible with WooCommerce Bookings v3.
> 
> In v3, the parent method `get_blocks_in_range_for_day()` now returns an associative array where keys are timestamps and values are booked counts:
> 
> ```
> $blocks[ $check_date ] = 0; // Returns [timestamp => booked_count]
> ```
> 
> However, the Accommodation Bookings override applies array_unique() to this result:
> 
> ```
> public function get_blocks_in_range( $start_date, $end_date, $intervals = array(), $resource_id = 0, $booked = array(), $get_past_times = false ) {
> $blocks_in_range = $this->get_blocks_in_range_for_day( $start_date, $end_date, $resource_id, $booked );
> return array_unique( $blocks_in_range );
> }
> ```
> 
> ## The Problem
> 
> When `array_unique()` is called on an associative array like `[1736380800 => 0, 1736467200 => 0, 1736553600 => 0, ...]`, it removes all entries with duplicate values, keeping only one. Since most days have a booked count of 0, this results in only a handful of dates being returned instead of all available dates.
> 
> ## Environment
> 
> WooCommerce Bookings: 3.0.0
> WooCommerce Accommodation Bookings: 1.3.6
> WooCommerce: 10.4.x
> WordPress: 6.9
> 
> ## Suggested Fix
> 
> Wrap it in a version check for the parent plugin.
> 
> The `array_unique()` call should be skipped if it is running with v3.0.0.
> 
> The parent class already handles deduplication via the associative array keys, so `array_unique()` is no longer necessary.

Closes https://github.com/woocommerce/woocommerce-accommodation-bookings/issues/563.
Closes https://linear.app/a8c/issue/WOOACBK-83/not-compatible-with-v300-of-woocommerce-bookings-new-associative-array.
Closes https://linear.app/a8c/issue/WOOACBK-84/bookings-v3-breaks-woocommerce-accomodation-bookings.

props @rtpHarry

This PR adds:
- A patch to fix the array structure
- Clears the old cache once

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

1. (`in trunk`) Create an accommodation product with 2 rooms per slot.
2. Add a few days to the cart, making sure to add separately, so there are multiple entries in the cart. Do not add both slots for the same day (keeping one slot available)
3. See the days added to the cart are booked on the calendar, and you can not book the other available one (this is the issue)
4. (`switch to fixed branch`), reload the page
5. See the previously added days in the cart are now available because they have one more day left for booking. (here the issue is fixed.) If you don't see the effect, try to visit the admin once, this will trigger the cache clearance, and check the calendar at FE again.

### Changelog entry
<!-- 
Each line should start with a change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Fix - Handled the Booked Blocks structure to display correct availability