### PR TITLE
Bug: Accommodation settings tab hidden for Shop Manager role

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,5 @@
 *** Changelog ***
 
-= 1.3.9 - xx-xx-xx =
-* Fix - Make the Accommodation settings tab visible to Shop Manager users by using the `manage_woocommerce` capability.
-
 = 1.3.8 - 2026-04-13 =
 * Dev - Bump WooCommerce "tested up to" version 10.7.
 * Dev - Bump WooCommerce minimum supported version to 10.5.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 1.3.9 - xx-xx-xx =
+* Fix - Make the Accommodation settings tab visible to Shop Manager users by using the `manage_woocommerce` capability.
+
 = 1.3.8 - 2026-04-13 =
 * Dev - Bump WooCommerce "tested up to" version 10.7.
 * Dev - Bump WooCommerce minimum supported version to 10.5.

--- a/includes/admin/class-wc-accommodation-booking-admin-product-settings.php
+++ b/includes/admin/class-wc-accommodation-booking-admin-product-settings.php
@@ -3,9 +3,8 @@ if ( ! defined( 'ABSPATH' ) )
 	exit;
 
 /**
- * Settings screen under WooCommerce > Settings > Products > Accommodations
- *
- * @version 1.3.9
+ * Adds the Accommodation tab to Bookings > Settings by hooking into
+ * the `woocommerce_bookings_settings_page` filter.
  */
 class WC_Accommodation_Booking_Admin_Product_Settings extends WC_Settings_API {
 	/**
@@ -76,6 +75,9 @@ class WC_Accommodation_Booking_Admin_Product_Settings extends WC_Settings_API {
 
 	/**
 	 * Initialize settings by using Bookings filter.
+	 *
+	 * @since x.x.x Capability changed from `manage_options` to `manage_woocommerce`
+	 *              so Shop Manager users can access the Accommodation tab.
 	 *
 	 * @param array $tabs_metadata Tabs metadata.
 	 *

--- a/includes/admin/class-wc-accommodation-booking-admin-product-settings.php
+++ b/includes/admin/class-wc-accommodation-booking-admin-product-settings.php
@@ -4,6 +4,8 @@ if ( ! defined( 'ABSPATH' ) )
 
 /**
  * Settings screen under WooCommerce > Settings > Products > Accommodations
+ *
+ * @version 1.3.9
  */
 class WC_Accommodation_Booking_Admin_Product_Settings extends WC_Settings_API {
 	/**
@@ -83,7 +85,7 @@ class WC_Accommodation_Booking_Admin_Product_Settings extends WC_Settings_API {
 		$tabs_metadata['accommodation'] = array(
 			'name'          => __( 'Accommodation', 'woocommerce-accommodation-bookings' ),
 			'href'          => admin_url( 'edit.php?post_type=wc_booking&page=wc_bookings_settings&tab=accommodation' ),
-			'capability'    => 'manage_options',
+			'capability'    => 'manage_woocommerce',
 			'generate_html' => 'WC_Accommodation_Booking_Admin_Product_Settings::generate_form_html',
 		);
 


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
The Accommodation tab under Bookings > Settings was using `manage_options`, which excludes Shop Manager users.

This PR updates the tab capability to `manage_woocommerce` so Shop Manager users can access Accommodation settings while keeping permissions scoped to roles with that WooCommerce capability.

Closes #337
Closes https://linear.app/a8c/issue/WOOACBK-5/bookings-settings-accommodation-invisible-to-shop-manager-role

### Steps to test the changes in this Pull Request:
1. Log in as a Shop Manager user.
2. Navigate to Bookings > Settings.
3. Confirm the Accommodation tab is visible.
4. Open the Accommodation tab and save settings.
5. Confirm settings save successfully.

### Changelog entry

> Fix - Make the Accommodation settings tab visible to Shop Manager users by using the `manage_woocommerce` capability.
