### PR TITLE
Replace @since x.x.x with target version 1.3.9

### DIFF
--- a/includes/admin/class-wc-accommodation-booking-admin-product-settings.php
+++ b/includes/admin/class-wc-accommodation-booking-admin-product-settings.php
@@ -76,7 +76,7 @@ class WC_Accommodation_Booking_Admin_Product_Settings extends WC_Settings_API {
 	/**
 	 * Initialize settings by using Bookings filter.
 	 *
-	 * @since x.x.x Capability changed from `manage_options` to `manage_woocommerce`
+	 * @since 1.3.9 Capability changed from `manage_options` to `manage_woocommerce`
 	 *              so Shop Manager users can access the Accommodation tab.
 	 *
 	 * @param array $tabs_metadata Tabs metadata.


### PR DESCRIPTION
## Summary

Follow-up to #641 addressing review feedback from @rtpHarry. The `@since x.x.x` placeholder on `add_accommodation_settings()` was carried over from the `woocommerce-bookings` convention by mistake — that repo intentionally uses `x.x.x` and lets the release manager rewrite it, but `woocommerce-accommodation-bookings` uses real version numbers in `@since` (every other tag in this file uses `1.13.0` etc.).

Stamping with `1.3.9`, the next release after the current `1.3.8`. If this should land in a different version (1.4.0, etc.), happy to update.

## Changelog

* Tweak - Replace placeholder `@since` tag with target version on the accommodation settings tab capability change from PR #641.

## Test plan

- [ ] No behaviour change — docblock-only update

Closes #646