### PR TITLE
Revert "Bug: WooCommerce Accommodation Booking requires WooCommerce Bookings & WooCommerce"

### DIFF
--- a/woocommerce-accommodation-bookings.php
+++ b/woocommerce-accommodation-bookings.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: WooCommerce Accommodation Bookings
- * Requires Plugins: woocommerce, woocommerce-bookings
+ * Requires Plugins: woocommerce
  * Plugin URI: https://woocommerce.com/products/woocommerce-accommodation-bookings/
  * Description: An accommodations add-on for the WooCommerce Bookings extension.
  * Version: 1.3.9


### PR DESCRIPTION
Reverts woocommerce/woocommerce-accommodation-bookings#579

PR reverts the PR #579, which adds `woocommerce-bookings` as a dependency to this, which is not hosted on wp.org. As per [docs](https://make.wordpress.org/core/2024/03/05/introducing-plugin-dependencies-in-wordpress-6-5/) on wp.org, WordPress.org can only declare dependencies that are also hosted on WordPress.org (check below). So, this PR reverts it.

> ### Limitations
> #### Plugins hosted on WordPress.org
> Dependent plugins hosted on WordPress.org can only declare dependencies that are also hosted on WordPress.org. If your plugin hosted on WordPress.org requires plugins that are not hosted there, it is recommended that you do not use the Requires Plugins header in your plugin at this time.

Closes https://linear.app/a8c/issue/WOOACBK-72/bug-woocommerce-accommodation-booking-requires-woocommerce-bookings