### PR TITLE
Remove redundant PHP version check for 7.4

### DIFF
--- a/includes/class-wc-accommodation-dependencies.php
+++ b/includes/class-wc-accommodation-dependencies.php
@@ -83,9 +83,5 @@ class WC_Accommodation_Dependencies {
 		if ( ! self::is_bookings_above_or_equal_to_version( '1.9.0' ) ) {
 			throw new Exception( esc_html__( 'Accommodation Bookings requires Bookings version 1.9+.', 'woocommerce-accommodation-bookings' ) );
 		}
-
-		if ( ! version_compare( PHP_VERSION, '7.4', '>=' ) ) {
-			throw new Exception( esc_html__( 'Accommodation Bookings requires PHP version 7.4 or above.', 'woocommerce-accommodation-bookings' ) );
-		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #659

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Fix - Remove redundant PHP version check for 7.4
