### PR TITLE
WOOACBK-157: Stop self-deactivating when Bookings dependency is missing

### DIFF
--- a/includes/class-wc-accommodation-bookings-plugin.php
+++ b/includes/class-wc-accommodation-bookings-plugin.php
@@ -177,7 +177,7 @@ class WC_Accommodation_Bookings_Plugin {
 	 */
 	public function dependency_notice() {
 		if ( is_wp_error( $this->dependencies_check_result ) ) {
-			$message = esc_html__( 'Dependencies check failed. Please make sure all dependencies are met.', 'woocommerce-accommodation-bookings' );
+			$message = esc_html__( 'Dependency check failed. Please make sure all dependencies are met.', 'woocommerce-accommodation-bookings' );
 			switch ( $this->dependencies_check_result->get_error_code() ) {
 				case 'BOOKINGS_NOT_ACTIVATED':
 					$message = esc_html__( 'Accommodation Bookings requires WooCommerce Bookings plugin activated.', 'woocommerce-accommodation-bookings' );
@@ -192,7 +192,7 @@ class WC_Accommodation_Bookings_Plugin {
 			echo wp_kses_post(
 				sprintf(
 					'<div class="error">%s</div>',
-					wpautop( esc_html( $message ) )
+					wpautop( $message )
 				)
 			);
 		}

--- a/includes/class-wc-accommodation-bookings-plugin.php
+++ b/includes/class-wc-accommodation-bookings-plugin.php
@@ -150,27 +150,51 @@ class WC_Accommodation_Bookings_Plugin {
 			WC_Accommodation_Dependencies::check_dependencies();
 			$this->dependencies_check_result = true;
 		} catch ( Exception $e ) {
-			if ( function_exists( 'deactivate_plugins' ) ) {
-				deactivate_plugins( plugin_basename( $this->plugin_file ) );
-			}
-
-			$this->dependencies_check_result = new WP_Error( 'unsatisfied_dependencies', $e->getMessage() );
-			add_action( 'admin_notices', array( $this, 'deactivate_notice' ) );
+			$this->dependencies_check_result = new WP_Error( $e->getMessage(), '' );
+			add_action( 'admin_notices', array( $this, 'dependency_notice' ) );
 		}
 
 		return $this->dependencies_check_result;
 	}
 
-
 	/**
 	 * Admin notice when plugin is automatically deactivated.
 	 *
+	 * @deprecated x.x.x Use dependency_notice() instead.
 	 * @return void
 	 */
 	public function deactivate_notice() {
+		wc_deprecated_function( __METHOD__, 'x.x.x', 'WC_Accommodation_Bookings_Plugin::dependency_notice' );
+		$this->dependency_notice();
+	}
+
+	/**
+	 * Admin notice when a required dependency is missing or outdated.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return void
+	 */
+	public function dependency_notice() {
 		if ( is_wp_error( $this->dependencies_check_result ) ) {
-			$error_message = esc_html( $this->dependencies_check_result->get_error_message() );
-			echo wp_kses_post( sprintf( '<div class="error">%s %s</div>', wpautop( $error_message ), wpautop( 'Plugin <strong>deactivated</strong>.' ) ) );
+			$message = esc_html__( 'Dependencies check failed. Please make sure all dependencies are met.', 'woocommerce-accommodation-bookings' );
+			switch ( $this->dependencies_check_result->get_error_code() ) {
+				case 'BOOKINGS_NOT_ACTIVATED':
+					$message = esc_html__( 'Accommodation Bookings requires WooCommerce Bookings plugin activated.', 'woocommerce-accommodation-bookings' );
+					break;
+				case 'BOOKINGS_VERSION_TOO_OLD':
+					$message = esc_html__( 'Accommodation Bookings requires WooCommerce Bookings version 1.9+.', 'woocommerce-accommodation-bookings' );
+					break;
+				case 'PHP_VERSION_TOO_OLD':
+					$message = esc_html__( 'Accommodation Bookings requires PHP version 7.4+.', 'woocommerce-accommodation-bookings' );
+					break;
+			}
+			echo wp_kses_post(
+				sprintf(
+					'<div class="error">%s</div>',
+					wpautop( esc_html( $message ) )
+				)
+			);
 		}
 	}
 

--- a/includes/class-wc-accommodation-dependencies.php
+++ b/includes/class-wc-accommodation-dependencies.php
@@ -77,15 +77,15 @@ class WC_Accommodation_Dependencies {
 		}
 
 		if ( ! self::is_bookings_installed() ) {
-			throw new Exception( esc_html__( 'Accommodation Bookings requires Bookings plugin activated.', 'woocommerce-accommodation-bookings' ) );
+			throw new Exception( 'BOOKINGS_NOT_ACTIVATED' );
 		}
 
 		if ( ! self::is_bookings_above_or_equal_to_version( '1.9.0' ) ) {
-			throw new Exception( esc_html__( 'Accommodation Bookings requires Bookings version 1.9+.', 'woocommerce-accommodation-bookings' ) );
+			throw new Exception( 'BOOKINGS_VERSION_TOO_OLD' );
 		}
 
 		if ( ! version_compare( PHP_VERSION, '7.4', '>=' ) ) {
-			throw new Exception( esc_html__( 'Accommodation Bookings requires PHP version 7.4 or above.', 'woocommerce-accommodation-bookings' ) );
+			throw new Exception( 'PHP_VERSION_TOO_OLD' );
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
As reported in WOOACBK-157, currently QIT Woo-API and Woo-E2E tests failing due to Accommodation Bookings self-deactivated when Bookings is not active. This PR updates behaviour to stop Accommodation Bookings from self-deactivating when WooCommerce Bookings is missing, outdated, or PHP is too old. The plugin stays active, shows a specific admin notice, and continues to skip feature registration via the existing `_register_hooks()` early return — so once Bookings is activated, Accommodation Bookings works on the next request without a manual reactivate cycle.

PR also fixes the `Function _load_textdomain_just_in_time was called incorrectly` by replacing translated admin notices with the error code at the time of dependency check. 

* Remove auto-deactivation on a failed dependency check; hook `dependency_notice` instead of `deactivate_notice`.
* Throw stable error codes from `WC_Accommodation_Dependencies` (`BOOKINGS_NOT_ACTIVATED`, `BOOKINGS_VERSION_TOO_OLD`, `PHP_VERSION_TOO_OLD`) and map them to translated admin notices.
* Soft-deprecate `deactivate_notice()` in favor of `dependency_notice()`.

Closes https://linear.app/a8c/issue/WOOACBK-157/fix-qit-woo-api-and-woo-e2e-tests-failing-due-to-self-deactivation

### Steps to test the changes in this Pull Request:
1. Fresh site with WooCommerce active and WooCommerce Bookings **not** installed/active. Activate Accommodation Bookings.
2. Confirm the plugin **stays active**, an admin notice says Bookings is required (and does **not** say the plugin was deactivated), and there are no PHP notices/warnings/fatals. Accommodation product type, settings tab, and related features should not appear.
3. Install and activate WooCommerce Bookings ≥ 1.9.0. Confirm the accommodation product type and settings appear on the next request without deactivating/reactivating Accommodation Bookings.
4. Deactivate Bookings again. Confirm the notice-only state returns with no fatals.
5. (Optional) With an old Bookings build (&lt; 1.9.0), confirm the version notice is shown and the plugin stays active.
6. Confirm `qit run:woo-api` and `qit run:woo-e2e` test pass.

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Fix - Accommodation Bookings no longer deactivates itself when WooCommerce Bookings is missing or outdated; an admin notice is shown instead.
