### PR TITLE
Compatibility testing with WordPress 7.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:  woocommerce, automattic
 Tags: woocommerce, bookings, accommodations
 Requires at least: 6.9
-Tested up to: 7.0
+Tested up to: 7.1
 Stable tag: 1.3.11
 License: GNU General Public License v3.0
 License URI: http://www.gnu.org/licenses/gpl-3.0.html

--- a/tests/e2e/global-teardown.js
+++ b/tests/e2e/global-teardown.js
@@ -25,7 +25,7 @@ module.exports = async (config) => {
       await adminPage.goto(
         `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=keys`
       );
-      await adminPage.locator("#the-list tr td.title").first().hover();
+      await adminPage.locator("#the-list tr .column-title.title").first().hover();
       await adminPage
         .getByRole("link", { name: "Revoke", includeHidden: true })
         .first()

--- a/tests/e2e/specs/order.spec.js
+++ b/tests/e2e/specs/order.spec.js
@@ -172,7 +172,7 @@ test.describe('Order Tests', () => {
 				hasText: ` has been confirmed (Order ${orderId}) -`,
 			})
 			.first();
-		await emailRow.locator('td.sent_date').hover();
+		await emailRow.locator('.column-sent_date.sent_date').hover();
 		await emailRow.locator('.view-content a').click();
 
 		const startDateTr = await adminPage

--- a/woocommerce-accommodation-bookings.php
+++ b/woocommerce-accommodation-bookings.php
@@ -9,7 +9,7 @@
  * Author URI: https://woocommerce.com
  * Text Domain: woocommerce-accommodation-bookings
  * Domain Path: /languages
- * Tested up to: 7.0
+ * Tested up to: 7.1
  * Requires at least: 6.9
  * WC tested up to: 11.0
  * WC requires at least: 10.8


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://linear.app/a8c/issue/WOOACBK-169/compatibility-testing-with-wordpress-71-rc

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

- Run the e2e test using GitHub action to test this PR.
- Overall plugin functionality

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Dev- Bump WordPress "Tested up to" to 7.1