### PR TITLE
ci: add job-level timeout-minutes to workflow jobs

### DIFF
--- a/.github/workflows/backlog-automation-issues.yml
+++ b/.github/workflows/backlog-automation-issues.yml
@@ -10,6 +10,7 @@ jobs:
   add-to-project:
     name: Add issue to project
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,6 +47,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       # Checkout the private action repository

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,6 +15,7 @@ jobs:
     if: "${{ ( github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'needs: e2e testing') ) ||  github.event_name == 'push' }}"
     name: E2E Test
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -5,6 +5,7 @@ on: pull_request
 jobs:
   changed:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -7,6 +7,7 @@ on:
 jobs:
     generate-zip-file:
         runs-on: ubuntu-latest
+        timeout-minutes: 5
         steps:
             - name: Checkout
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/gh-issue-gen.yml
+++ b/.github/workflows/gh-issue-gen.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   create-gh-issue:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       LINEAR_TEAM: WOOACBK

--- a/.github/workflows/php-compat.yml
+++ b/.github/workflows/php-compat.yml
@@ -6,6 +6,7 @@ jobs:
   php-compatibility:
     name: PHP compatibility
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -5,6 +5,7 @@ on: pull_request
 jobs:
   phpcs:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/qit.yml
+++ b/.github/workflows/qit.yml
@@ -37,6 +37,7 @@ jobs:
     needs: build
     name: run
     runs-on: ubuntu-latest
+    timeout-minutes: 40
 
     env:
       NO_COLOR: 1

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -10,6 +10,7 @@ jobs:
   typos:
     name: Check for typos
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Add job timeouts so runs fail fast instead of hanging for up to 6 hours.

| Job | Median (30d) | Max (30d) | `timeout-minutes` |
| -- | -- | -- | -- |
| `backlog-automation-issues.yml` / `add-to-project` | no runs | no runs | 5 |
| `deploy.yml` / `deploy` | 10.4 min | 11.7 min | 15 |
| `e2e.yml` / `e2e` | 9.7 min | 10.3 min | 15 |
| `eslint.yml` / `changed` | 0.3 min | 1.1 min | 5 |
| `generate-zip.yml` / `generate-zip-file` | 0.9 min | 0.9 min | 5 |
| `gh-issue-gen.yml` / `create-gh-issue` | 0.1 min | 0.2 min | 5 |
| `php-compat.yml` / `php-compatibility` | 1.3 min | 2.5 min | 5 |
| `phpcs.yml` / `phpcs` | 0.3 min | 0.5 min | 5 |
| `plugin-check.yml` / `test` | 1.8 min | 2.7 min | 5 |
| `qit.yml` / `test` | 32.4 min | 32.4 min | 40 |
| `spell-check.yml` / `typos` | 0.1 min | 0.2 min | 5 |

`qit.yml` / `build` calls `generate-zip.yml` with `uses:`, where `timeout-minutes` is not valid. The limit on `generate-zip-file` covers it.

Part of TESTOPS-272

Closes #699