### PR TITLE
[CI] Increase deploy job timeout to 60 minutes.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 60
 
     steps:
       # Checkout the private action repository


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
- Increase the deploy job timeout-minutes in .github/workflows/deploy.yml from 15 to 60.
- The previous 15-minute limit was too short and caused the deploy job to time out before the release could complete. Raising it to 60 minutes gives the deploy enough time to finish.

Last 2 Deploy action run failed due to timeout, Deploy is important step and shouldn't have tight timeout limit:
https://github.com/woocommerce/woocommerce-accommodation-bookings/actions/workflows/deploy.yml

Closes # .

cc: @adimoldovan (As you set limit on the PR https://github.com/woocommerce/woocommerce-accommodation-bookings/pull/698)

### Steps to test the changes in this Pull Request:
Verify file changes and make sure it looks accurate.

### Changelog entry
n/a

Closes #710